### PR TITLE
Lateral menu fixes

### DIFF
--- a/src/ui/organisms/Menu/index.tsx
+++ b/src/ui/organisms/Menu/index.tsx
@@ -46,7 +46,8 @@ export const Menu = () => {
             <Logo size="Medium" href="/trading" />
           </S.Logo>
           <S.Container>
-            <S.WrapperIcon isEnabled={router.pathname === "/trading/[id]"}>
+            <S.WrapperIcon>
+              {router.pathname === "/trading/[id]" && <S.LineBorder />}
               <Link href="/trading">
                 <div>
                   <Icon name="Exchange" background="none" stroke="text" size="large" />
@@ -54,9 +55,8 @@ export const Menu = () => {
                 <S.Span>Exchange</S.Span>
               </Link>
             </S.WrapperIcon>
-            <S.WrapperIcon
-              isDisabled={!isAuthenticated}
-              isEnabled={router.pathname === "/balances"}>
+            <S.WrapperIcon isDisabled={!isAuthenticated}>
+              {router.pathname === "/balances" && <S.LineBorder />}
               <Link href="/balances">
                 <div>
                   <Icon name="Coins" background="none" stroke="text" size="large" />
@@ -64,9 +64,8 @@ export const Menu = () => {
                 <S.Span>Balances</S.Span>
               </Link>
             </S.WrapperIcon>
-            <S.WrapperIcon
-              isDisabled={!isAuthenticated}
-              isEnabled={router.pathname === "/settings"}>
+            <S.WrapperIcon isDisabled={!isAuthenticated}>
+              {router.pathname === "/settings" && <S.LineBorder />}
               <Link href="/settings">
                 <div>
                   <Icon name="Wallet" background="none" stroke="text" size="large" />

--- a/src/ui/organisms/Menu/styles.ts
+++ b/src/ui/organisms/Menu/styles.ts
@@ -8,10 +8,9 @@ export const Logo = styled.div`
 `;
 
 export const WrapperIcon = styled.div<{
-  isEnabled?: boolean;
   isDisabled?: boolean;
 }>`
-  ${({ theme, isEnabled, isDisabled = false }) => css`
+  ${({ theme, isDisabled = false }) => css`
     position: relative;
     display: flex;
     flex-direction: row;
@@ -19,7 +18,7 @@ export const WrapperIcon = styled.div<{
     width: fit-content;
     cursor: pointer;
     pointer-events: ${isDisabled ? "none" : "auto"};
-    border-left: ${isEnabled ? "4px solid #e6007a;" : "none"};
+    opacity: ${isDisabled ? 0.4 : 1};
     :hover {
       ${Span},${TermsLinks} {
         opacity: 1;
@@ -27,18 +26,26 @@ export const WrapperIcon = styled.div<{
         transform: translateY(0);
       }
       ${Span} {
-        visibility: ${isEnabled ? "hidden" : "visible"};
+        visibility: ${isDisabled ? "hidden" : "visible"};
       }
     }
     ${Icon} {
       border-radius: 10rem;
-      margin-left: ${isEnabled ? "2px" : "5px"};
+      margin-left: 5px;
     }
   `}
 `;
 
 export const ThemeIcon = styled.div`
   margin-left: -5px !important;
+`;
+
+export const LineBorder = styled.span`
+  height: 30px;
+  width: 3px;
+  background-color: #e6007a;
+  border-radius: 99px;
+  margin-right: -2px;
 `;
 
 export const SpanWrapper = styled.div``;


### PR DESCRIPTION
**Description -**
 
There are some issues in Ordebook. 

1. Position of tooltip when hovering on menu buttons does not seems correct. Earlier, it was different.
2. On clicking on avatar change, menubar shifts upward
3. On active menu link, add a left border


https://user-images.githubusercontent.com/65214523/237015834-fabcfa67-89ba-4aba-9e40-c3205b9b7f6a.mp4

**Solution -**

https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/cdc6bb9b-83a7-43d1-9d62-9e4cfec54107


**Tasks -**

- [x]  Fix Position of tooltip as it was was earlier
- [x] Prevent MenuBar Shifting upward when Click on Avatar Change Button
- [x] Add Left Border on Active Menu Link