### PR TITLE
Default Main url from /migration to /trading

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -54,5 +54,5 @@ export const defaultConfig: DefaultConfig = {
     "/withdraw",
   ],
   underMaintenance: process.env.UNDER_MAINTENACE?.split(","),
-  mainUrl: process.env.MAIN_URL || "/migration",
+  mainUrl: process.env.MAIN_URL || "/trading",
 };


### PR DESCRIPTION
### Description 

This pull request aims to eliminate the need for manual URL adjustments during development mode by changing the default main URL from /migration to /trading.
