### PR TITLE
Fix/Open Beta 531

### DIFF
--- a/src/providers/user/tradeWallet/provider.tsx
+++ b/src/providers/user/tradeWallet/provider.tsx
@@ -66,6 +66,10 @@ export const TradeWalletProvider: T.TradeWalletComponent = ({ children }) => {
     const { file, password } = payload;
     let tradeAddress = "";
     try {
+      if (state.registerAccountModal.selectedAddress.address !== file.address) {
+        onHandleError("Incorrect JSON File");
+        return;
+      }
       const modifiedFile = file;
       const pair = keyring.restoreAccount(modifiedFile, password);
       tradeAddress = pair?.address;
@@ -84,7 +88,7 @@ export const TradeWalletProvider: T.TradeWalletComponent = ({ children }) => {
       if (tradeAddress?.length)
         dispatch(A.removeTradeAccountFromBrowser({ address: tradeAddress }));
       dispatch(A.registerTradeAccountError(error));
-      onHandleError("Cannot import account, Invalid password or file");
+      onHandleError("Can't Import Account, Invalid password or file");
     }
   };
 

--- a/src/ui/templates/Settings/index.tsx
+++ b/src/ui/templates/Settings/index.tsx
@@ -257,6 +257,10 @@ export const SettingsTemplate = () => {
                                       onClick={() =>
                                         tradeWalletState.onRegisterAccountModalActive({
                                           defaultImportActive: true,
+                                          data: {
+                                            name: account.name,
+                                            address: account.address,
+                                          },
                                         })
                                       }>
                                       Import


### PR DESCRIPTION
## Issue - https://github.com/Polkadex-Substrate/Polkadex-Open-Beta/issues/531

## Description

While Importing a Trading Account from JSON File, It imports it even if provided JSON file does not belongs to that Trading Account which we wanna import. 

## Changes Made

We will change the state when one clicks on Import Button for any Trading Account. We will save the information (i.e. name, address) for that particular Trade Account. When JSON file would be uploaded, then we will make sure address of JSON file and the address we saved earlier in the state is same or not. If it's not same, we will throw an error. 

## How to Test

https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/187c735a-dc5b-4513-bd9f-04582acb7edb

## Screenshots / Screencasts

https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/edb454db-bc75-4ba9-9e92-a42ab1f5c971

## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Open Beta Issue](https://github.com/Polkadex-Substrate/Polkadex-Open-Beta/issues/).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
