### PR TITLE
Withdraw Button Style fixed

### DIFF
--- a/src/ui/organisms/Funds/styles.ts
+++ b/src/ui/organisms/Funds/styles.ts
@@ -103,7 +103,6 @@ export const Link = styled.div`
     border-radius: 0.4rem;
     padding: 0.2rem 0.4rem;
     font-size: 1.3rem;
-    color: ${theme.colors.white};
     transition: background 0.4s ease-in-out;
     border: 1px solid ${theme.colors.secondaryBackground};
     cursor: pointer;
@@ -114,6 +113,7 @@ export const WithdrawLink = styled(Link)``;
 export const DepositLink = styled(Link)`
   ${({ theme }) => css`
     background: ${theme.colors.green};
+    color: ${theme.colors.white};
     :hover {
       background-color: ${theme.colors.green}33;
     }


### PR DESCRIPTION
## Issue - [#543](https://github.com/Polkadex-Substrate/Polkadex-Open-Beta/issues/543)

## Description

Withdraw button is not visible in light mode (under Funds tab)

## Screenshots / Screencasts

![image](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/ed877891-0799-4667-aae3-43fb0ef0739e)

![image](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/49f50f92-1fcb-4bf6-8160-dd841da63917)

## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Open Beta Issue](https://github.com/Polkadex-Substrate/Polkadex-Open-Beta/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
