### PR TITLE
Trading page changes

### DIFF
--- a/src/ui/organisms/Markets/index.tsx
+++ b/src/ui/organisms/Markets/index.tsx
@@ -134,7 +134,6 @@ const Content: FC<{
             tokenTicker={token.tokenTickerName}
             vol={Decimal.format(Number(token.volume), token.quote_precision, ",")}
             price={Decimal.format(Number(token.last), token.quote_precision, ",")}
-            fiat={Decimal.format(Number(token.last), token.quote_precision, ",")}
             change={Decimal.format(Number(token.price_change_percent), 2, ",") + "%"}
             changeMarket={() => changeMarket(token.name)}
             handleSelectedFavorite={handleSelectedFavorite}
@@ -154,7 +153,6 @@ const Card = ({
   tokenTicker,
   vol,
   price,
-  fiat,
   change,
   changeMarket,
   isFavourite,
@@ -187,7 +185,6 @@ const Card = ({
         </S.CardInfoContent>
         <S.CardPricing>
           <span>{price}</span>
-          <p>{fiat}</p>
         </S.CardPricing>
         <S.CardChange isNegative={isNegative(change.toString())}>
           <span>{change}</span>

--- a/src/ui/organisms/RecentTrades/styles.ts
+++ b/src/ui/organisms/RecentTrades/styles.ts
@@ -19,7 +19,7 @@ export const Main = styled.div<{ hasData?: boolean }>`
     flex-flow: column;
     flex: 1;
     border-radius: 0 2rem 2rem 0rem;
-    min-width: 29rem;
+    min-width: 28rem;
     width: 100%;
     height: 100%;
     min-height: 48rem;


### PR DESCRIPTION
## Issue : [Changes in trading page](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues/753)

## Description
Currently we dont have fiat values so it needs to be removed from markets and the recent trades table is being cut off on some screen sizes
<!--- Provide a brief summary of the changes made in this pull request -->

## Changes Made
- [x] Removed fiat value from markets
- [x] Fixed recent trades being cut off on small screen problem

<!--- Describe the changes made in this pull request in more detail. Include any relevant technical details that may be helpful for reviewers to know. -->

## How to Test

<!--- Provide instructions for how to test the changes in this pull request. This should include any relevant dependencies, environment variables, or configurations that may be necessary. -->




## Screenshots / Screencasts
https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/68969089/339f6b2a-dea0-4e46-92e9-4947ac0d472f




<img width="392" alt="Screenshot 2023-08-01 at 1 07 32 AM" src="https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/68969089/697731c8-3e9d-44cc-8bc2-88a21769890e">

<!--- Include any relevant screenshots or screencasts that may help reviewers better understand the changes made in this pull request -->

## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
