### PR TITLE
Date issue fixed with withdrawl history

### DIFF
--- a/src/ui/templates/Withdraw/index.tsx
+++ b/src/ui/templates/Withdraw/index.tsx
@@ -410,7 +410,7 @@ const HistoryTable = ({ items }) => {
                 <S.Cell>
                   <span>
                     {intlFormat(
-                      item.date,
+                      new Date(item.time),
                       {
                         year: "2-digit",
                         month: "2-digit",


### PR DESCRIPTION
## Description

Withdrawl history always showing current date and time

## Changes Made

1. Data coming from backend does not have date in it, instead it has time key (which contains date)
2. Just removed `item.date` and put `item.time`

## How to Test

![image](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/d2560c8c-e418-4592-8e39-5b37bb98709e)

## Screenshots / Screencasts

![image](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/39f91b0b-cdf1-4d4f-8585-1ee8b9e286f5)


## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [ ] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
