### PR TITLE
Corner case fix for Ready to claim button

### DIFF
--- a/src/helpers/groupWithdrawsBySnapshotIds.ts
+++ b/src/helpers/groupWithdrawsBySnapshotIds.ts
@@ -9,7 +9,7 @@ export type WithdrawGroup = {
 export type WithdrawGroupItem = {
   id: number;
   asset: string;
-  date: string | Date;
+  time: string | Date;
   stid: number;
   amount: string;
   status: string;
@@ -34,7 +34,7 @@ export const groupWithdrawsBySnapShotIds = (
           id,
           stid: item.stid,
           asset: item.asset,
-          date: new Date(item.time),
+          time: new Date(item.time),
           amount: item.amount,
           status: item.status,
         });

--- a/src/ui/templates/Withdraw/index.tsx
+++ b/src/ui/templates/Withdraw/index.tsx
@@ -410,7 +410,7 @@ const HistoryTable = ({ items }) => {
                 <S.Cell>
                   <span>
                     {intlFormat(
-                      new Date(item.time ?? item.date),
+                      new Date(item.time),
                       {
                         year: "2-digit",
                         month: "2-digit",


### PR DESCRIPTION
## Description

Fixed corner case for Ready to claim tab in withdraw page

## How to Test

https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/876215be-7302-4664-9c2d-21e018e4c8ab

## Screenshots / Screencasts

https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/e5ffcfc2-8fd5-46a0-88f1-fb62fb74bc8d

## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
