### PR TITLE
Nuel/show market errors

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -40,7 +40,7 @@ export const USER_EVENTS = {
   // send to trade address
   TradeFormat: "TradeFormat",
   // Errors from server
-  Error: "error",
+  error: "error",
 };
 
 export type UserEvents = keyof typeof USER_EVENTS;

--- a/src/providers/user/orderHistoryProvider/provider.tsx
+++ b/src/providers/user/orderHistoryProvider/provider.tsx
@@ -253,6 +253,20 @@ export const OrderHistoryProvider = ({ children }) => {
     }
   }, [onOrderUpdates, tradeAddress]);
 
+  // for markets order errors the event type is error
+  useEffect(() => {
+    if (tradeAddress?.length) {
+      const subscription = eventHandler({
+        cb: () => onHandleError(`Cannot fully fill market order: not enough liquidity`),
+        name: tradeAddress,
+        eventType: "error",
+      });
+      return () => {
+        subscription.unsubscribe();
+      };
+    }
+  }, [onHandleError, tradeAddress]);
+
   return (
     <Provider
       value={{


### PR DESCRIPTION
market liquidity errors are relayed through the error stream of the backend. this pr adds a listener to listen to the stream for errors happening during matching.