### PR TITLE
added validation for password for buy and sell

### DIFF
--- a/src/ui/molecules/MarketOrderAction/index.tsx
+++ b/src/ui/molecules/MarketOrderAction/index.tsx
@@ -18,6 +18,7 @@ import { Decimal, Icons } from "@polkadex/orderbook-ui/atoms";
 import { selectTradeAccount } from "@polkadex/orderbook/providers/user/tradeWallet/helper";
 import { useProfile } from "@polkadex/orderbook/providers/user/profile";
 import { useTradeWallet } from "@polkadex/orderbook/providers/user/tradeWallet";
+import { buySellValidation } from "@polkadex/orderbook/validations";
 
 export const MarketOrderAction = ({ isSell = false, isLimit, form, setForm }) => {
   const {
@@ -156,11 +157,12 @@ const ProtectPassword = () => {
   // if account is not protected by password use default password to unlock account.
   useTryUnlockTradeAccount(tradeAccount);
 
-  const { values, setFieldValue, handleSubmit } = useFormik({
+  const { values, setFieldValue, handleSubmit, errors } = useFormik({
     initialValues: {
       showPassword: false,
       password: "",
     },
+    validationSchema: buySellValidation,
     onSubmit: (values) => {
       isValidSize &&
         tradeAccount.isLocked &&
@@ -172,7 +174,6 @@ const ProtectPassword = () => {
   });
 
   const isLoading = false;
-  const error = "";
 
   const isValidSize = useMemo(() => values?.password?.length === 5, [values.password]);
 
@@ -197,7 +198,7 @@ const ProtectPassword = () => {
               onChange={(e) => setFieldValue("password", e)}
               value={values.password}
               name="password"
-              error={error.length && error}
+              error={errors.password}
               type={values.showPassword ? "password" : "tel"}
             />
           </S.ProtectPasswordContent>

--- a/src/validations/index.ts
+++ b/src/validations/index.ts
@@ -131,3 +131,7 @@ export const importValiations = () => {
       .required("Required"),
   });
 };
+
+export const buySellValidation = Yup.object().shape({
+  password: Yup.string().matches(/^[0-9]+$/, "Must be only digits"),
+});


### PR DESCRIPTION
## Issue : [dont allow non-numeric characters in trading password input](https://github.com/Polkadex-Substrate/Polkadex-Open-Beta/issues/550)
## Description
Creating a trading account forces numerical characters only but the buy and sell form does not  have the same check.
<!--- Provide a brief summary of the changes made in this pull request -->

## Changes Made

- [x] Added validation to the buy and sell form

<!--- Describe the changes made in this pull request in more detail. Include any relevant technical details that may be helpful for reviewers to know. -->

## How to Test

<!--- Provide instructions for how to test the changes in this pull request. This should include any relevant dependencies, environment variables, or configurations that may be necessary. -->

## Screenshots / Screencasts
https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/68969089/3cc7e3a3-9d81-4272-a147-9bf537019882

<!--- Include any relevant screenshots or screencasts that may help reviewers better understand the changes made in this pull request -->

## Checklist



<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
