### PR TITLE
Fix client side errors

### DIFF
--- a/src/providers/user/balancesProvider/reducer.tsx
+++ b/src/providers/user/balancesProvider/reducer.tsx
@@ -44,6 +44,9 @@ export const balancesReducer = (
       const old = state.balances.find(
         (i) => i.assetId.toString() === update.assetId.toString()
       );
+      if(!old) {
+        return state
+      }
       const newBalance: Balance = {
         ...old,
         ...update,


### PR DESCRIPTION
onChain balance may not be present if the user has not opened balances page before causing the client side error.