### PR TITLE
Restricted the decimals

### DIFF
--- a/src/ui/templates/Balances/index.tsx
+++ b/src/ui/templates/Balances/index.tsx
@@ -23,7 +23,6 @@ import { useNativeApi } from "@polkadex/orderbook/providers/public/nativeApi";
 import { Icons } from "@polkadex/orderbook-ui/atoms";
 import { defaultConfig } from "@polkadex/orderbook-config";
 import { Keyboard } from "@polkadex/orderbook-ui/molecules/LoadingIcons";
-import { formatNumber } from "@polkadex/web-helpers";
 
 export const BalancesTemplate = () => {
   const { t } = useTranslation("balances");
@@ -158,29 +157,17 @@ export const BalancesTemplate = () => {
                                   </Table.Cell>
                                   <Table.Cell>
                                     <S.Cell>
-                                      <span>
-                                        {formatNumber(
-                                          Number(balance?.free_balance || 0).toFixed(8)
-                                        )}{" "}
-                                      </span>
+                                      <span>{Number(balance?.free_balance || 0)} </span>
                                     </S.Cell>
                                   </Table.Cell>
                                   <Table.Cell>
                                     <S.Cell>
-                                      <span>
-                                        {formatNumber(
-                                          Number(balance?.onChainBalance || 0).toFixed(8)
-                                        )}{" "}
-                                      </span>
+                                      <span>{Number(balance?.onChainBalance || 0)} </span>
                                     </S.Cell>
                                   </Table.Cell>
                                   <Table.Cell>
                                     <S.Cell>
-                                      <span>
-                                        {formatNumber(
-                                          Number(balance?.reserved_balance || 0).toFixed(8)
-                                        )}{" "}
-                                      </span>
+                                      <span>{Number(balance?.reserved_balance || 0)} </span>
                                     </S.Cell>
                                   </Table.Cell>
                                   <Table.Cell>


### PR DESCRIPTION
## Description

We are seeing too many unwanted zeros, which makes no sense. So, it's better to trim the amount by removing those zeros. It's better to write - 

E.g. 0.00000000 = 0
       0.30000000 = 0.3 and so on


![Image](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/9cfd0971-8e22-457c-a395-bc6a6f63b6c1)

## Screenshots / Screencasts

![image](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/3125e8e2-c9b9-4ce6-986c-49a924bd5267)

## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
