### PR TITLE
Fixing balances Page intro guide Don't show again issue

### DIFF
--- a/apps/web/src/ui/templates/Balances/intro.tsx
+++ b/apps/web/src/ui/templates/Balances/intro.tsx
@@ -18,13 +18,14 @@ import * as S from "./styles";
 import { defaulIntrotStyles } from "@/styles/introStyles";
 import { CheckboxCustom } from "@/ui/molecules";
 const isClientSide = typeof window !== "undefined";
-const initialState =
-  isClientSide && localStorage.getItem(DEFAULTBALANCESINTRONAME) === "true";
 
 export const Intro = ({
   children,
   active,
 }: PropsWithChildren<{ active: boolean }>) => {
+  const initialState =
+    isClientSide && localStorage.getItem(DEFAULTBALANCESINTRONAME) === "true";
+
   const steps: StepType[] = [
     {
       selector: ".depositButton",
@@ -114,6 +115,8 @@ const Actions = ({
   return <>{children}</>;
 };
 const ContentComponent = (props: PopoverContentProps) => {
+  const initialState =
+    isClientSide && localStorage.getItem(DEFAULTBALANCESINTRONAME) === "true";
   const [state, setState] = useState(!!initialState);
   const content = props.steps[props.currentStep].content;
   const isLastStep = props.currentStep === props.steps.length - 1;
@@ -153,7 +156,6 @@ const ContentComponent = (props: PopoverContentProps) => {
               onClick={() => {
                 props.setCurrentStep(0);
                 props.setIsOpen(false);
-                handleChangeIntroView();
               }}
             >
               {isLastStep ? "Done" : "Skip"}


### PR DESCRIPTION
## Description

This pull request addresses a issue where the 'Don't Show Again' feature in the intro guide on the Balances page was not functioning as intended. Users were unable to dismiss the guide.


## Screenshots / Screencasts

https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/12574469/4d1f055d-88a6-4438-ba60-40b9298bd338

## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
