### PR TITLE
update: fixed balance formatting

### DIFF
--- a/packages/core/src/helpers/formatting.ts
+++ b/packages/core/src/helpers/formatting.ts
@@ -4,7 +4,7 @@ const DIGITS_AFTER_DECIMAL = 4;
 
 // TODO: Need to make it more configurable
 export const formatBalances = (value: string) => {
-  value = Number(value).toFixed(20);
+  value = Number(value).toFixed(4);
   let balance = trimFloat({
     value,
     digitsAfterDecimal: DIGITS_AFTER_DECIMAL,


### PR DESCRIPTION
## Description

Balance is not being formatted properly. 

If balance is 1.3405E-8 => it was returning 1.3405, now it returns 0 which is expected
Similarly, for 1E-8, now it returns 0

## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
