### PR TITLE
Fix Minimum IBTC Transfer Amount Validation

### DIFF
--- a/packages/core/src/validations/index.ts
+++ b/packages/core/src/validations/index.ts
@@ -45,7 +45,7 @@ export const depositValidations = (
       .test(
         ErrorMessages.TOO_SMALL,
         ErrorMessages.TOO_SMALL,
-        (value) => Number(value) > 0.0001
+        (value) => Number(value) >= 0.0001
       )
       .test(
         ErrorMessages.CHECK_BALANCE,
@@ -145,7 +145,7 @@ export const withdrawValidations = (balance: string) => {
       .test(
         ErrorMessages.TOO_SMALL,
         ErrorMessages.TOO_SMALL,
-        (value) => Number(value) > 0.0001
+        (value) => Number(value) >= 0.0001
       )
       .test(
         ErrorMessages.CHECK_BALANCE,


### PR DESCRIPTION
## Description

This pull request resolves the issue related to the minimum IBTC transfer amount validation. Currently, the system incorrectly restricts transfers to amounts greater than 0.0001. However, as per the specified criteria, the minimum transfer amount should include 0.0001, which is now allowed.

Changes Made:

- [x] Updated the validation logic to permit transfers equal to or greater than 0.0001.


## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
