### PR TITLE
fix: load trade accounts

### DIFF
--- a/packages/core/src/providers/user/tradeWallet/provider.tsx
+++ b/packages/core/src/providers/user/tradeWallet/provider.tsx
@@ -31,8 +31,7 @@ export const TradeWalletProvider: T.TradeWalletComponent = ({ children }) => {
     selectedAccount,
   } = useProfile();
   const nativeApiState = useNativeApi();
-  const { onHandleError, onHandleNotification, hasExtension } =
-    useSettingsProvider();
+  const { onHandleError, onHandleNotification } = useSettingsProvider();
 
   // Actions
   const onExportTradeAccount = (
@@ -377,8 +376,8 @@ export const TradeWalletProvider: T.TradeWalletComponent = ({ children }) => {
   }, [onTradeAccountUpdate, tradeAddress]);
 
   useEffect(() => {
-    if (authInfo.isAuthenticated && hasExtension) onLoadTradeAccounts();
-  }, [onLoadTradeAccounts, authInfo.isAuthenticated, hasExtension]);
+    if (authInfo.isAuthenticated) onLoadTradeAccounts();
+  }, [onLoadTradeAccounts, authInfo.isAuthenticated]);
 
   return (
     <Provider


### PR DESCRIPTION
## Description

Load trade accounts available in browser even if one don't have polkadotjs (or any) extension.

## Screenshots / Screencasts

https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/a2375c7f-a2cb-406f-a74b-b7f0905e7a9b

## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [ ] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
