### PR TITLE
Spelling Mistake on Balances Page

### DIFF
--- a/apps/web/src/ui/organisms/BalancesTable/columns.tsx
+++ b/apps/web/src/ui/organisms/BalancesTable/columns.tsx
@@ -91,7 +91,7 @@ export const columns = (headers: string[]) => [
               style={{ transform: "translateY(-0.8rem)" }}
               background="text"
             >
-              <S.TooltipMessage>Extenal link</S.TooltipMessage>
+              <S.TooltipMessage>External link</S.TooltipMessage>
             </TooltipContent>
           </Tooltip>
 
@@ -114,7 +114,7 @@ export const columns = (headers: string[]) => [
               style={{ transform: "translateY(-0.8rem)" }}
               background="text"
             >
-              <S.TooltipMessage>Extenal link</S.TooltipMessage>
+              <S.TooltipMessage>External link</S.TooltipMessage>
             </TooltipContent>
           </Tooltip>
           <Link


### PR DESCRIPTION
## Description

This pull request addresses a spelling mistake on the Balances page where the word "extenal" was incorrectly used instead of "external".

## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.

Close: https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues/992
