### PR TITLE
fix: refetch orderbook and precision

### DIFF
--- a/apps/hestia/src/components/trading/Orderbook/index.tsx
+++ b/apps/hestia/src/components/trading/Orderbook/index.tsx
@@ -65,7 +65,8 @@ export const Orderbook = ({ id }: { id: string }) => {
         </div>
         <Skeleton loading={!!loading}>
           <Table
-            precision={sizeState.length}
+            pricePrecision={sizeState.length}
+            qtyPrecision={qtyPrecision}
             isSell
             active={filterState !== "OrderDesc"}
             asks={asks}
@@ -81,7 +82,8 @@ export const Orderbook = ({ id }: { id: string }) => {
         />
         <Skeleton loading={!!loading}>
           <Table
-            precision={sizeState.length}
+            pricePrecision={sizeState.length}
+            qtyPrecision={qtyPrecision}
             active={filterState !== "OrderAsc"}
             asks={asks}
             bids={bids}

--- a/apps/hestia/src/components/trading/Orderbook/table.tsx
+++ b/apps/hestia/src/components/trading/Orderbook/table.tsx
@@ -10,14 +10,16 @@ import { GenericAction } from "./columns";
 
 export const Table = ({
   isSell = false,
-  precision,
+  pricePrecision,
+  qtyPrecision,
   active,
   orders,
   asks,
   bids,
 }: {
   isSell?: boolean;
-  precision: number;
+  pricePrecision: number;
+  qtyPrecision: number;
   active?: boolean;
   orders: string[][];
   bids: string[][];
@@ -110,7 +112,7 @@ export const Table = ({
               }}
             >
               <Decimal
-                fixed={precision}
+                fixed={pricePrecision}
                 thousSep=","
                 // prevValue={orders[i + 1] ? orders[i + 1][0] : 0}
               >
@@ -127,7 +129,7 @@ export const Table = ({
               }}
               className="justify-self-end"
             >
-              <Decimal fixed={precision} thousSep=",">
+              <Decimal fixed={qtyPrecision} thousSep=",">
                 {amount}
               </Decimal>
             </Typography.Text>
@@ -141,7 +143,7 @@ export const Table = ({
               }}
               className="justify-self-end pr-2"
             >
-              <Decimal fixed={precision} thousSep=",">
+              <Decimal fixed={pricePrecision} thousSep=",">
                 {total[i]}
               </Decimal>
             </Typography.Text>

--- a/packages/core/src/hooks/useOrderbook.ts
+++ b/packages/core/src/hooks/useOrderbook.ts
@@ -28,11 +28,12 @@ export function useOrderbook(defaultMarket: string) {
   const { onHandleError } = useSettingsProvider();
   const {
     currentTicker: { currentPrice },
+    tickerLoading,
   } = useTickers(defaultMarket);
 
   const { isPriceUp } = useRecentTrades(defaultMarket);
 
-  const { data, isLoading, isFetching } = useQuery({
+  const { data, isLoading, isRefetching } = useQuery({
     queryKey: QUERY_KEYS.orderBook(defaultMarket),
     queryFn: async () => {
       const orderbook =
@@ -56,6 +57,7 @@ export function useOrderbook(defaultMarket: string) {
       onHandleError(errorMessage);
     },
     refetchOnMount: false,
+    refetchInterval: 30 * 1000, // 30s
   });
 
   const [asks, bids] = [
@@ -91,7 +93,7 @@ export function useOrderbook(defaultMarket: string) {
     qtyPrecision,
     lastPriceValue: currentPrice,
     hasMarket: !!currentMarket,
-    loading: isLoading || isFetching,
+    loading: isRefetching ? false : isLoading || tickerLoading,
     asks,
     bids,
     initialState,


### PR DESCRIPTION
## Description

In this PR, we are adding a refetch interval of orderbook data of 30 seconds & fixing the precision for amount.

## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
