### PR TITLE
Removal of Referral Link in Orderbook 

### DIFF
--- a/apps/hestia/src/components/ui/Header/FundWalletModal/index.tsx
+++ b/apps/hestia/src/components/ui/Header/FundWalletModal/index.tsx
@@ -193,7 +193,7 @@ export const FundWalletModal = ({
                   asChild
                 >
                   <Link
-                    href="https://www.kucoin.com/trade/PDEX-USDT?rcode=rPH7VCS"
+                    href="https://www.kucoin.com/trade/PDEX-USDT"
                     target="_blank"
                   >
                     Kucoin


### PR DESCRIPTION
## Description

This pull request aims to address the accidental inclusion of a referral link in the Orderbook platform. The link was mistakenly added weeks ago and needs to be removed promptly. This PR ensures the removal of the referral link from the Orderbook interface.


## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.

Close: https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues/1175


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Modified `FundWalletModal` component to remove a query parameter from the URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->