### PR TITLE
Remove Swap Slot Popup 

### DIFF
--- a/apps/hestia/src/components/trading/template.tsx
+++ b/apps/hestia/src/components/trading/template.tsx
@@ -7,8 +7,6 @@ import { useWindowSize } from "react-use";
 import classNames from "classnames";
 import { Resizable, ImperativePanelHandle } from "@polkadex/ux";
 
-import { QuickStart } from "../ui/Footer/QuickStart";
-
 import { AssetInfo } from "./AssetInfo";
 import { Orderbook } from "./Orderbook";
 import { Trades } from "./Trades";
@@ -31,7 +29,7 @@ export function Template({ id }: { id: string }) {
   const orderbookPanelRef = useRef<ImperativePanelHandle>(null);
 
   const { width } = useWindowSize();
-  const { open, onOpenChange, onClose } = useTour();
+  const { onOpenChange } = useTour();
   const { list } = useMarkets();
   const currentMarket = getCurrentMarket(list, id);
 
@@ -41,7 +39,6 @@ export function Template({ id }: { id: string }) {
 
   return (
     <Fragment>
-      <QuickStart open={open} onOpenChange={onClose} />
       <ConnectTradingInteraction />
       <Header />
       {mobileView ? (


### PR DESCRIPTION
## Description

This pull request addresses the removal of the swap slot popup feature from Orderbook UI. 


## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.


Close: https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues/1191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed `QuickStart` component import and usage in `Template` component.
	- No longer using the `onClose` function in the `Template` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->