### PR TITLE
Issue with Sign-Required Calls

### DIFF
--- a/packages/core/src/helpers/signAndSendExtrinsic.ts
+++ b/packages/core/src/helpers/signAndSendExtrinsic.ts
@@ -114,8 +114,7 @@ export const handleTransaction = async (
             const errMsg = dispatchError.toString();
             reject(new Error(errMsg));
           }
-        } else if (status.isInBlock || status.isFinalized) {
-          handleExtrinsicError(events, signedExtrinsic);
+        } else if (status.isFinalized) {
           resolve({
             isSuccess: true,
             eventMessages: events,
@@ -125,28 +124,3 @@ export const handleTransaction = async (
       })
       .catch((error) => reject(error));
   });
-
-export const handleExtrinsicError = (
-  events: EventRecord[],
-  api: SubmittableExtrinsicPromise
-) => {
-  events
-    // find/filter for failed events
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    .filter(({ event }) => api.events.system.ExtrinsicFailed.is(event))
-    // we know that data for system.ExtrinsicFailed is
-    // (DispatchError, DispatchInfo)
-    .forEach(
-      ({
-        event: {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          data: [error],
-        },
-      }) => {
-        // Other, CannotLookup, BadOrigin, no extra info
-        throw Error(`Error: ${error.toHuman()}`);
-      }
-    );
-};


### PR DESCRIPTION
## Description

This PR addresses the issue where sign-in required calls are causing extended loading times. 

## Changes Made

- [x] fix: check if the transactions is finalized
- [x] fix: removed handleExtrinsicError call

## Screenshot
https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/12574469/74a72609-7fd2-4dce-81f6-8a0f42e96e38

## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.

Close: https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues/1196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
    - Simplified error handling logic in the `handleTransaction` function of `signAndSendExtrinsic.ts`.
    - Removed the `handleExtrinsicError` function for processing failed events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->