### PR TITLE
Header Links Display fix

### DIFF
--- a/apps/hestia/src/components/ui/Header/index.tsx
+++ b/apps/hestia/src/components/ui/Header/index.tsx
@@ -53,7 +53,7 @@ export const Header = forwardRef<HTMLDivElement>((_, ref) => {
       >
         <div className="flex-1 flex items-center gap-5 py-2 overflow-auto">
           <Link
-            href={"/"}
+            href="/"
             className="md:flex-1 md:max-w-[140px] max-md:w-8 max-md:h-8 max-md:overflow-hidden"
           >
             <Logo.Orderbook className="max-md:pointer-events-none max-md:h-8 max-md:[&_g]:hidden" />

--- a/apps/hestia/src/components/ui/Header/index.tsx
+++ b/apps/hestia/src/components/ui/Header/index.tsx
@@ -58,7 +58,7 @@ export const Header = forwardRef<HTMLDivElement>((_, ref) => {
           >
             <Logo.Orderbook className="max-md:pointer-events-none max-md:h-8 max-md:[&_g]:hidden" />
           </Link>
-          <div className="gap-5 hidden items-center lg:flex">
+          <div className="gap-5 hidden items-center lg:!flex">
             <HeaderLink.Single href={lastUsedMarketUrl}>
               Trade
             </HeaderLink.Single>


### PR DESCRIPTION
## Description

Fixed header links display

## Current View
<img width="1920" alt="image" src="https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/e9207bcb-1f98-4644-bf76-5b7bbb73ff51">

## Expected view
<img width="1920" alt="image" src="https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/698fd549-3258-4c8c-92d5-b5f817aad5c1">


## Checklist

- [ ] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [ ] I have requested a review from at least one other contributor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the class name in the header component to improve styling and layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->