### PR TITLE
Uniformity in Balances <> Orderbook Frontend

### DIFF
--- a/apps/hestia/src/components/trading/PlaceOrder/index.tsx
+++ b/apps/hestia/src/components/trading/PlaceOrder/index.tsx
@@ -3,13 +3,10 @@
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { Tabs } from "@polkadex/ux";
 import { Market } from "@orderbook/core/utils/orderbookService/types";
-import {
-  tryUnlockTradeAccount,
-  decimalPlaces,
-  trimFloat,
-} from "@orderbook/core/helpers";
+import { tryUnlockTradeAccount } from "@orderbook/core/helpers";
 import { useConnectWalletProvider } from "@orderbook/core/providers/user/connectWalletProvider";
 import { useFunds, useTickers } from "@orderbook/core/hooks";
+import { BalanceFormatter } from "@orderbook/format";
 
 import { LimitOrder } from "./Limit";
 import { MarketOrder } from "./Market";
@@ -18,30 +15,27 @@ import { Unlock } from "./unlock";
 type Props = { market?: Market; isBuy?: boolean; isResponsive?: boolean };
 
 export const PlaceOrder = ({ market, isBuy, isResponsive }: Props) => {
+  const toHuman = BalanceFormatter.toHuman;
   const [isPasswordProtected, setIsPasswordProtected] = useState(false);
   const { selectedAccount } = useConnectWalletProvider();
   const { getFreeProxyBalance } = useFunds();
   const { currentTicker } = useTickers(market?.id);
 
-  const pricePrecision = (market && decimalPlaces(market.price_tick_size)) || 0;
-  const qtyPrecision = (market && decimalPlaces(market.qty_step_size)) || 0;
-
   const [availableQuoteAmount, availableBaseAmount] = useMemo(() => {
-    const quoteAmount = trimFloat({
-      value: getFreeProxyBalance(market?.quoteAsset?.id || "-1"),
-      digitsAfterDecimal: pricePrecision,
-    });
-    const baseAmount = trimFloat({
-      value: getFreeProxyBalance(market?.baseAsset?.id || "-1"),
-      digitsAfterDecimal: qtyPrecision,
-    });
+    const quoteAmount = toHuman(
+      Number(getFreeProxyBalance(market?.quoteAsset?.id || "-1")),
+      8
+    );
+    const baseAmount = toHuman(
+      Number(getFreeProxyBalance(market?.baseAsset?.id || "-1")),
+      8
+    );
     return [+quoteAmount, +baseAmount];
   }, [
     getFreeProxyBalance,
     market?.baseAsset?.id,
     market?.quoteAsset?.id,
-    pricePrecision,
-    qtyPrecision,
+    toHuman,
   ]);
 
   useEffect(() => {

--- a/apps/hestia/src/components/ui/ConnectWallet/insufficientBalance.tsx
+++ b/apps/hestia/src/components/ui/ConnectWallet/insufficientBalance.tsx
@@ -86,7 +86,7 @@ export const InsufficientBalance = ({
                     <div className="flex flex-items gap-1">
                       {!poolsSuccess ? (
                         <>
-                          <Skeleton loading className="h-10 mt-2" />
+                          <Skeleton loading className="h-12 mt-2" />
                         </>
                       ) : (
                         pools?.map((asset) => {

--- a/apps/hestia/src/hooks/useQueryPools.ts
+++ b/apps/hestia/src/hooks/useQueryPools.ts
@@ -13,6 +13,7 @@ export const useQueryPools = () => {
     error: poolsError,
   } = useQuery({
     queryKey: QUERY_KEYS.queryPools(),
+    enabled: !!swap && !!assets,
     queryFn: async () => {
       if (!swap || !assets) return;
       const data = await swap.queryPools();

--- a/packages/core/src/constants/queryKeys.ts
+++ b/packages/core/src/constants/queryKeys.ts
@@ -96,5 +96,5 @@ export const QUERY_KEYS = {
     assetName,
     assetsAmount,
   ],
-  queryPools: () => [PREFIX],
+  queryPools: () => [PREFIX, "queryPools"],
 };


### PR DESCRIPTION
## Description

In place order component, balance is being shown by trimming it's some of the part which is not the desired behavior. Some Centralized exchanges like Kucoin and Binance are showing the full balance but adding the validation so that user can input the values according to the validations only.

In our case, we already have all the validations implemented btu we are trimming the balances with some market configurations values which is not really required. So, we will just remove those trimming and make balance uniform everywhere in the app.

https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/32ef4ef8-4fe1-48c2-9d57-f9749c0daf2d

## Checklist

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
