### PR TITLE
Remove QuickStart from All Pages and Disable "Convert Small Balance to PDEX" Button 

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "development"
+  ],
+  "hints": {
+    "no-inline-styles": "off"
+  }
+}

--- a/.hintrc
+++ b/.hintrc
@@ -1,8 +1,0 @@
-{
-  "extends": [
-    "development"
-  ],
-  "hints": {
-    "no-inline-styles": "off"
-  }
-}

--- a/apps/hestia/src/components/balances/template.tsx
+++ b/apps/hestia/src/components/balances/template.tsx
@@ -2,21 +2,19 @@
 
 import { HoverCard, Popover, Typography, Checkbox, Input } from "@polkadex/ux";
 import { useResizeObserver, useWindowSize } from "usehooks-ts";
-import { Fragment, useMemo, useRef } from "react";
-import Link from "next/link";
+import { useMemo, useRef } from "react";
 import { RiMore2Line, RiInformation2Line } from "@remixicon/react";
 import { useAssets } from "@orderbook/core/hooks";
 import { useConnectWalletProvider } from "@orderbook/core/providers/user/connectWalletProvider";
 
 import { ResponsiveProfile } from "../ui/Header/Profile/responsiveProfile";
-import { QuickStart } from "../ui/Footer/QuickStart";
 
 import { Overview } from "./Overview";
 import { Table } from "./Table";
 import { Help } from "./Help";
 
 import { Footer, Header } from "@/components/ui";
-import { useSizeObserver, useTour } from "@/hooks";
+import { useSizeObserver } from "@/hooks";
 
 export function Template() {
   const headerRef = useRef<HTMLDivElement | null>(null);
@@ -26,7 +24,6 @@ export function Template() {
   const [interactionRef, interactionHeight] = useSizeObserver();
   const { width } = useWindowSize();
 
-  const { onOpenChange } = useTour();
   const { height: overviewHeight = 0 } = useResizeObserver({
     ref: overviewRef,
     box: "border-box",
@@ -85,11 +82,11 @@ export function Template() {
               />
               {width >= 680 ? (
                 <div className="flex items-center gap-4">
-                  <HoverCard>
+                  <HoverCard open={false}>
                     <HoverCard.Trigger>
-                      <Link href="/" className="text-primary-base text-sm">
+                      <Typography.Text appearance="disabled">
                         Convert small balance to PDEX
-                      </Link>
+                      </Typography.Text>
                     </HoverCard.Trigger>
                     <HoverCard.Content className="max-w-[15rem]">
                       After each trade, you might have a bit of residual balance
@@ -126,11 +123,11 @@ export function Template() {
                           Hide 0 balances
                         </Checkbox.Label>
                       </Checkbox.Solid>{" "}
-                      <HoverCard>
+                      <HoverCard open={false}>
                         <HoverCard.Trigger>
-                          <Link href="/" className="text-primary-base">
+                          <Typography.Text appearance="disabled">
                             Convert small balance to PDEX
-                          </Link>
+                          </Typography.Text>
                         </HoverCard.Trigger>
                         <HoverCard.Content className="max-w-[15rem]">
                           After each trade, you might have a bit of residual
@@ -159,9 +156,7 @@ export function Template() {
           />
         </div>
       )}
-      {!mobileView && (
-        <Footer onOpenChange={onOpenChange} marketsActive ref={footerRef} />
-      )}
+      {!mobileView && <Footer marketsActive ref={footerRef} />}
     </div>
   );
 }

--- a/apps/hestia/src/components/balances/template.tsx
+++ b/apps/hestia/src/components/balances/template.tsx
@@ -26,7 +26,7 @@ export function Template() {
   const [interactionRef, interactionHeight] = useSizeObserver();
   const { width } = useWindowSize();
 
-  const { open, onClose, onOpenChange } = useTour();
+  const { onOpenChange } = useTour();
   const { height: overviewHeight = 0 } = useResizeObserver({
     ref: overviewRef,
     box: "border-box",
@@ -54,117 +54,114 @@ export function Template() {
   );
 
   return (
-    <Fragment>
-      <QuickStart open={open} onOpenChange={onClose} />
-      <div
-        className="flex flex-1 flex-col bg-backgroundBase h-full"
-        vaul-drawer-wrapper=""
+    <div
+      className="flex flex-1 flex-col bg-backgroundBase h-full"
+      vaul-drawer-wrapper=""
+    >
+      <Header ref={headerRef} />
+      <main
+        className="flex flex-1 overflow-auto border-x border-secondary-base w-full max-w-[1920px] h-full m-auto"
+        style={{
+          paddingBottom: mobileView
+            ? `${interactionHeight}px`
+            : `${footerHeight}px`,
+        }}
       >
-        <Header ref={headerRef} />
-        <main
-          className="flex flex-1 overflow-auto border-x border-secondary-base w-full max-w-[1920px] h-full m-auto"
-          style={{
-            paddingBottom: mobileView
-              ? `${interactionHeight}px`
-              : `${footerHeight}px`,
-          }}
-        >
-          <div className="flex-1 flex flex-col">
-            <div ref={overviewRef} className="flex flex-col">
-              <div className="flex items-center justify-between px-4 pt-6 pb-4 border-b border-secondary-base">
-                <Typography.Text bold size="lg">
-                  Balances
-                </Typography.Text>
-                <RiInformation2Line className="w-6 h-6 text-primary" />
-              </div>
-              <Overview />
-              <div className="py-2 flex items-center justify-between gap-2 border-b border-primary px-4">
-                <Input.Search
-                  placeholder="Search.."
-                  value={filters.search}
-                  onChange={onSearchToken}
-                  className="max-sm:focus:text-[16px]"
-                />
-                {width >= 680 ? (
-                  <div className="flex items-center gap-4">
-                    <HoverCard>
-                      <HoverCard.Trigger>
-                        <Link href="/" className="text-primary-base text-sm">
-                          Convert small balance to PDEX
-                        </Link>
-                      </HoverCard.Trigger>
-                      <HoverCard.Content className="max-w-[15rem]">
-                        After each trade, you might have a bit of residual
-                        balance in your account wallet. Polkadex allows you to
-                        convert dust valued under 0.000012 BTC into PDEX.
-                      </HoverCard.Content>
-                    </HoverCard>
-                    <Checkbox.Solid
-                      id="hideZeroBalances"
-                      checked={filters.hideZero}
-                      onCheckedChange={onHideZeroBalance}
-                    >
-                      <Checkbox.Label htmlFor="hideZeroBalances">
-                        Hide 0 balances
-                      </Checkbox.Label>
-                    </Checkbox.Solid>
-                  </div>
-                ) : (
-                  <Popover>
-                    <Popover.Trigger className="group">
-                      <RiMore2Line className="w-6 h-6 text-primary group-hover:text-current transition-colors duration-300" />
-                    </Popover.Trigger>
-                    <Popover.Content className="flex flex-col gap-5 p-4">
-                      <Typography.Text appearance="secondary" size="xs">
-                        Filters
-                      </Typography.Text>
-                      <div className="flex flex-col gap-2">
-                        <Checkbox.Solid
-                          id="hideZeroBalances"
-                          checked={filters.hideZero}
-                          onCheckedChange={onHideZeroBalance}
-                        >
-                          <Checkbox.Label htmlFor="hideZeroBalances">
-                            Hide 0 balances
-                          </Checkbox.Label>
-                        </Checkbox.Solid>{" "}
-                        <HoverCard>
-                          <HoverCard.Trigger>
-                            <Link href="/" className="text-primary-base">
-                              Convert small balance to PDEX
-                            </Link>
-                          </HoverCard.Trigger>
-                          <HoverCard.Content className="max-w-[15rem]">
-                            After each trade, you might have a bit of residual
-                            balance in your account wallet. Polkadex allows you
-                            to convert dust valued under 0.000012 BTC into PDEX.
-                          </HoverCard.Content>
-                        </HoverCard>
-                      </div>
-                    </Popover.Content>
-                  </Popover>
-                )}
-              </div>
+        <div className="flex-1 flex flex-col">
+          <div ref={overviewRef} className="flex flex-col">
+            <div className="flex items-center justify-between px-4 pt-6 pb-4 border-b border-secondary-base">
+              <Typography.Text bold size="lg">
+                Balances
+              </Typography.Text>
+              <RiInformation2Line className="w-6 h-6 text-primary" />
             </div>
-            <Table maxHeight={maxHeight} data={assets} loading={loading} />
-            <Help ref={helpRef} />
+            <Overview />
+            <div className="py-2 flex items-center justify-between gap-2 border-b border-primary px-4">
+              <Input.Search
+                placeholder="Search.."
+                value={filters.search}
+                onChange={onSearchToken}
+                className="max-sm:focus:text-[16px]"
+              />
+              {width >= 680 ? (
+                <div className="flex items-center gap-4">
+                  <HoverCard>
+                    <HoverCard.Trigger>
+                      <Link href="/" className="text-primary-base text-sm">
+                        Convert small balance to PDEX
+                      </Link>
+                    </HoverCard.Trigger>
+                    <HoverCard.Content className="max-w-[15rem]">
+                      After each trade, you might have a bit of residual balance
+                      in your account wallet. Polkadex allows you to convert
+                      dust valued under 0.000012 BTC into PDEX.
+                    </HoverCard.Content>
+                  </HoverCard>
+                  <Checkbox.Solid
+                    id="hideZeroBalances"
+                    checked={filters.hideZero}
+                    onCheckedChange={onHideZeroBalance}
+                  >
+                    <Checkbox.Label htmlFor="hideZeroBalances">
+                      Hide 0 balances
+                    </Checkbox.Label>
+                  </Checkbox.Solid>
+                </div>
+              ) : (
+                <Popover>
+                  <Popover.Trigger className="group">
+                    <RiMore2Line className="w-6 h-6 text-primary group-hover:text-current transition-colors duration-300" />
+                  </Popover.Trigger>
+                  <Popover.Content className="flex flex-col gap-5 p-4">
+                    <Typography.Text appearance="secondary" size="xs">
+                      Filters
+                    </Typography.Text>
+                    <div className="flex flex-col gap-2">
+                      <Checkbox.Solid
+                        id="hideZeroBalances"
+                        checked={filters.hideZero}
+                        onCheckedChange={onHideZeroBalance}
+                      >
+                        <Checkbox.Label htmlFor="hideZeroBalances">
+                          Hide 0 balances
+                        </Checkbox.Label>
+                      </Checkbox.Solid>{" "}
+                      <HoverCard>
+                        <HoverCard.Trigger>
+                          <Link href="/" className="text-primary-base">
+                            Convert small balance to PDEX
+                          </Link>
+                        </HoverCard.Trigger>
+                        <HoverCard.Content className="max-w-[15rem]">
+                          After each trade, you might have a bit of residual
+                          balance in your account wallet. Polkadex allows you to
+                          convert dust valued under 0.000012 BTC into PDEX.
+                        </HoverCard.Content>
+                      </HoverCard>
+                    </div>
+                  </Popover.Content>
+                </Popover>
+              )}
+            </div>
           </div>
-        </main>
-        {mobileView && (browserAccountPresent || extensionAccountPresent) && (
-          <div
-            ref={interactionRef}
-            className="flex flex-col gap-4 bg-level-1 border-t border-primary py-3 px-2 fixed bottom-0 left-0 w-full"
-          >
-            <ResponsiveProfile
-              extensionAccountPresent={extensionAccountPresent}
-              browserAccountPresent={browserAccountPresent}
-            />
-          </div>
-        )}
-        {!mobileView && (
-          <Footer onOpenChange={onOpenChange} marketsActive ref={footerRef} />
-        )}
-      </div>
-    </Fragment>
+          <Table maxHeight={maxHeight} data={assets} loading={loading} />
+          <Help ref={helpRef} />
+        </div>
+      </main>
+      {mobileView && (browserAccountPresent || extensionAccountPresent) && (
+        <div
+          ref={interactionRef}
+          className="flex flex-col gap-4 bg-level-1 border-t border-primary py-3 px-2 fixed bottom-0 left-0 w-full"
+        >
+          <ResponsiveProfile
+            extensionAccountPresent={extensionAccountPresent}
+            browserAccountPresent={browserAccountPresent}
+          />
+        </div>
+      )}
+      {!mobileView && (
+        <Footer onOpenChange={onOpenChange} marketsActive ref={footerRef} />
+      )}
+    </div>
   );
 }

--- a/apps/hestia/src/components/cexOnRamp/template.tsx
+++ b/apps/hestia/src/components/cexOnRamp/template.tsx
@@ -14,13 +14,11 @@ import { ResponsiveProfile } from "../ui/Header/Profile/responsiveProfile";
 import { Help } from "./Help";
 
 import { Footer, Header } from "@/components/ui";
-import { useTour } from "@/hooks";
 
 const extend = themeConfig.theme.extend;
 
 export function Template() {
   const { width } = useWindowSize();
-  const { onOpenChange } = useTour();
 
   const headerRef = useRef<HTMLDivElement | null>(null);
   const helpRef = useRef<HTMLDivElement | null>(null);
@@ -103,7 +101,7 @@ export function Template() {
             />
           </div>
         )}
-        {!mobileView && <Footer onOpenChange={onOpenChange} ref={footerRef} />}
+        {!mobileView && <Footer ref={footerRef} />}
       </div>
     </Fragment>
   );

--- a/apps/hestia/src/components/cexOnRamp/template.tsx
+++ b/apps/hestia/src/components/cexOnRamp/template.tsx
@@ -9,7 +9,6 @@ import { useResizeObserver, useWindowSize } from "usehooks-ts";
 
 import { themeConfig } from "../../../../../themeConfig";
 import { ConnectTradingInteraction } from "../ui/ConnectWalletInteraction/connectTradingInteraction";
-import { QuickStart } from "../ui/Footer/QuickStart";
 import { ResponsiveProfile } from "../ui/Header/Profile/responsiveProfile";
 
 import { Help } from "./Help";
@@ -21,7 +20,7 @@ const extend = themeConfig.theme.extend;
 
 export function Template() {
   const { width } = useWindowSize();
-  const { onOpenChange, open, onClose } = useTour();
+  const { onOpenChange } = useTour();
 
   const headerRef = useRef<HTMLDivElement | null>(null);
   const helpRef = useRef<HTMLDivElement | null>(null);
@@ -66,7 +65,6 @@ export function Template() {
 
   return (
     <Fragment>
-      <QuickStart open={open} onOpenChange={onClose} />
       <ConnectTradingInteraction />
       <div
         className="flex flex-1 flex-col bg-backgroundBase h-full"

--- a/apps/hestia/src/components/rewards/template.tsx
+++ b/apps/hestia/src/components/rewards/template.tsx
@@ -14,7 +14,6 @@ import classNames from "classnames";
 import { START_EPOCH } from "@orderbook/core/constants";
 
 import { ResponsiveProfile } from "../ui/Header/Profile/responsiveProfile";
-import { QuickStart } from "../ui/Footer/QuickStart";
 
 import { Table } from "./Table";
 import { Help } from "./Help";
@@ -71,7 +70,7 @@ export function Template() {
   const { browserAccountPresent, extensionAccountPresent } =
     useConnectWalletProvider();
 
-  const { onClose, onOpenChange, open } = useTour();
+  const { onOpenChange } = useTour();
   useEffect(() => {
     const epochsLength = epochs?.length || 0;
     if (epochs && epochs?.length > 2) {
@@ -80,155 +79,152 @@ export function Template() {
   }, [epochs]);
 
   return (
-    <Fragment>
-      <QuickStart open={open} onOpenChange={onClose} />
-      <div
-        className="flex flex-1 flex-col bg-backgroundBase h-full"
-        vaul-drawer-wrapper=""
+    <div
+      className="flex flex-1 flex-col bg-backgroundBase h-full"
+      vaul-drawer-wrapper=""
+    >
+      <Header ref={headerRef} />
+      <main
+        className="flex flex-1 overflow-hidden border-x border-secondary-base w-full max-w-[1920px] m-auto"
+        style={{
+          paddingBottom: mobileView
+            ? `${interactionHeight}px`
+            : `${footerHeight}px`,
+        }}
       >
-        <Header ref={headerRef} />
-        <main
-          className="flex flex-1 overflow-hidden border-x border-secondary-base w-full max-w-[1920px] m-auto"
-          style={{
-            paddingBottom: mobileView
-              ? `${interactionHeight}px`
-              : `${footerHeight}px`,
-          }}
-        >
-          <Tabs value={tab} onValueChange={setTab}>
-            <div className="flex-1 flex flex-col">
-              <div ref={overviewRef} className="flex flex-col">
-                <div className="flex items-end justify-between gap-4 px-4 pt-6 pb-4 border-b border-secondary-base flex-wrap">
-                  <Typography.Text bold size="lg">
-                    Rewards
-                  </Typography.Text>
-                  <RiInformation2Line className="w-6 h-6 text-primary" />
-                </div>
-                <div className="flex max-md:flex-col md:items-center border-b border-primary w-full">
-                  <HoverCard>
-                    <HoverCard.Trigger className="cursor-pointer h-full transition-colors duration-300 hover:bg-level-0">
-                      <div className="flex items-center gap-2 px-4 py-2 h-full">
-                        <RiInformation2Line className="w-3 h-3 text-primary" />
-                        <Typography.Paragraph className="whitespace-nowrap">
-                          Period (Epoch)
-                        </Typography.Paragraph>
-                      </div>
-                    </HoverCard.Trigger>
-                    <HoverCard.Content>
-                      <Info />
-                    </HoverCard.Content>
-                  </HoverCard>
-                  <Tabs.List className="w-full max-md:border-t border-primary">
-                    {isLoading ? (
-                      <Skeleton loading className="h-20 max-w-[500px]" />
-                    ) : (
-                      <Carousel
-                        options={{ align: "start", startIndex: 10 }}
-                        className={classNames(
-                          "mx-8 w-full",
-                          epochs?.length && epochs?.length >= 3
-                            ? "md:max-w-[500px]"
-                            : "md:max-w-[300px]"
-                        )}
-                      >
-                        <Carousel.Content className="gap-2">
-                          {epochs?.map((value, index) => {
-                            const active = value.epoch.toString() === tab;
-                            const isLast = index === epochs?.length - 1;
-                            return (
-                              <Carousel.Item
+        <Tabs value={tab} onValueChange={setTab}>
+          <div className="flex-1 flex flex-col">
+            <div ref={overviewRef} className="flex flex-col">
+              <div className="flex items-end justify-between gap-4 px-4 pt-6 pb-4 border-b border-secondary-base flex-wrap">
+                <Typography.Text bold size="lg">
+                  Rewards
+                </Typography.Text>
+                <RiInformation2Line className="w-6 h-6 text-primary" />
+              </div>
+              <div className="flex max-md:flex-col md:items-center border-b border-primary w-full">
+                <HoverCard>
+                  <HoverCard.Trigger className="cursor-pointer h-full transition-colors duration-300 hover:bg-level-0">
+                    <div className="flex items-center gap-2 px-4 py-2 h-full">
+                      <RiInformation2Line className="w-3 h-3 text-primary" />
+                      <Typography.Paragraph className="whitespace-nowrap">
+                        Period (Epoch)
+                      </Typography.Paragraph>
+                    </div>
+                  </HoverCard.Trigger>
+                  <HoverCard.Content>
+                    <Info />
+                  </HoverCard.Content>
+                </HoverCard>
+                <Tabs.List className="w-full max-md:border-t border-primary">
+                  {isLoading ? (
+                    <Skeleton loading className="h-20 max-w-[500px]" />
+                  ) : (
+                    <Carousel
+                      options={{ align: "start", startIndex: 10 }}
+                      className={classNames(
+                        "mx-8 w-full",
+                        epochs?.length && epochs?.length >= 3
+                          ? "md:max-w-[500px]"
+                          : "md:max-w-[300px]"
+                      )}
+                    >
+                      <Carousel.Content className="gap-2">
+                        {epochs?.map((value, index) => {
+                          const active = value.epoch.toString() === tab;
+                          const isLast = index === epochs?.length - 1;
+                          return (
+                            <Carousel.Item
+                              key={value.epoch}
+                              className={classNames(
+                                "max-md:px-3 max-md:py-4 md:p-5 basis-1/2 max-md:!w-2 w-10",
+                                epochs.length >= 3 && "md:basis-1/3",
+                                isLast && "pointer-events-none"
+                              )}
+                            >
+                              <Tabs.Trigger
+                                value={value.epoch.toString()}
                                 key={value.epoch}
-                                className={classNames(
-                                  "max-md:px-3 max-md:py-4 md:p-5 basis-1/2 max-md:!w-2 w-10",
-                                  epochs.length >= 3 && "md:basis-1/3",
-                                  isLast && "pointer-events-none"
-                                )}
                               >
-                                <Tabs.Trigger
-                                  value={value.epoch.toString()}
-                                  key={value.epoch}
+                                <HoverCard
+                                  defaultOpen={value.status === "Ongoing"}
                                 >
-                                  <HoverCard
-                                    defaultOpen={value.status === "Ongoing"}
-                                  >
-                                    <HoverCard.Trigger>
-                                      <div className="flex flex-col items-start">
-                                        <Typography.Text
-                                          bold
-                                          appearance={
-                                            active ? "primary-base" : "primary"
-                                          }
-                                        >
-                                          {value.status === "Ongoing" && "*"}
-                                          Epoch {value.epoch}
-                                        </Typography.Text>
-                                        <Typography.Text appearance="secondary">
-                                          {value.status === "Ongoing" &&
-                                            "Current Period"}
-                                          {value.status === "Upcoming" &&
-                                            "Next Period"}
-                                          {value.status === "Ended" &&
-                                            "Previous Period"}
-                                        </Typography.Text>
-                                      </div>
-                                    </HoverCard.Trigger>
-                                    <HoverCard.Content side="top">
-                                      {value.status}
-                                    </HoverCard.Content>
-                                  </HoverCard>
-                                </Tabs.Trigger>
-                              </Carousel.Item>
-                            );
-                          })}
-                        </Carousel.Content>
-                        <Carousel.Previous
-                          className="h-full w-8 -left-8 border-x border-primary"
-                          variant="light"
-                          appearance="secondary"
-                        >
-                          <RiArrowLeftSLine className="w-full h-full" />
-                        </Carousel.Previous>
-                        <Carousel.Next
-                          className="h-full w-8 -right-8 border-x border-primary"
-                          variant="light"
-                          appearance="secondary"
-                        >
-                          <RiArrowRightSLine className="w-full h-full" />
-                        </Carousel.Next>
-                      </Carousel>
-                    )}
-                  </Tabs.List>
-                </div>
+                                  <HoverCard.Trigger>
+                                    <div className="flex flex-col items-start">
+                                      <Typography.Text
+                                        bold
+                                        appearance={
+                                          active ? "primary-base" : "primary"
+                                        }
+                                      >
+                                        {value.status === "Ongoing" && "*"}
+                                        Epoch {value.epoch}
+                                      </Typography.Text>
+                                      <Typography.Text appearance="secondary">
+                                        {value.status === "Ongoing" &&
+                                          "Current Period"}
+                                        {value.status === "Upcoming" &&
+                                          "Next Period"}
+                                        {value.status === "Ended" &&
+                                          "Previous Period"}
+                                      </Typography.Text>
+                                    </div>
+                                  </HoverCard.Trigger>
+                                  <HoverCard.Content side="top">
+                                    {value.status}
+                                  </HoverCard.Content>
+                                </HoverCard>
+                              </Tabs.Trigger>
+                            </Carousel.Item>
+                          );
+                        })}
+                      </Carousel.Content>
+                      <Carousel.Previous
+                        className="h-full w-8 -left-8 border-x border-primary"
+                        variant="light"
+                        appearance="secondary"
+                      >
+                        <RiArrowLeftSLine className="w-full h-full" />
+                      </Carousel.Previous>
+                      <Carousel.Next
+                        className="h-full w-8 -right-8 border-x border-primary"
+                        variant="light"
+                        appearance="secondary"
+                      >
+                        <RiArrowRightSLine className="w-full h-full" />
+                      </Carousel.Next>
+                    </Carousel>
+                  )}
+                </Tabs.List>
               </div>
-              <div className="flex flex-col flex-1">
-                <Table
-                  ref={tableRowsRef}
-                  maxHeight={maxHeight}
-                  selectedEpoch={+tab}
-                />
-              </div>
-              <Help ref={helpRef} />
             </div>
-          </Tabs>
-        </main>
-        {mobileView ? (
-          (browserAccountPresent || extensionAccountPresent) && (
-            <Fragment>
-              <div
-                ref={interactionRef}
-                className="flex flex-col gap-4 bg-level-1 border-t border-primary py-3 px-2 fixed bottom-0 left-0 w-full"
-              >
-                <ResponsiveProfile
-                  extensionAccountPresent={extensionAccountPresent}
-                  browserAccountPresent={browserAccountPresent}
-                />
-              </div>
-            </Fragment>
-          )
-        ) : (
-          <Footer onOpenChange={onOpenChange} ref={footerRef} />
-        )}
-      </div>
-    </Fragment>
+            <div className="flex flex-col flex-1">
+              <Table
+                ref={tableRowsRef}
+                maxHeight={maxHeight}
+                selectedEpoch={+tab}
+              />
+            </div>
+            <Help ref={helpRef} />
+          </div>
+        </Tabs>
+      </main>
+      {mobileView ? (
+        (browserAccountPresent || extensionAccountPresent) && (
+          <Fragment>
+            <div
+              ref={interactionRef}
+              className="flex flex-col gap-4 bg-level-1 border-t border-primary py-3 px-2 fixed bottom-0 left-0 w-full"
+            >
+              <ResponsiveProfile
+                extensionAccountPresent={extensionAccountPresent}
+                browserAccountPresent={browserAccountPresent}
+              />
+            </div>
+          </Fragment>
+        )
+      ) : (
+        <Footer onOpenChange={onOpenChange} ref={footerRef} />
+      )}
+    </div>
   );
 }

--- a/apps/hestia/src/components/rewards/template.tsx
+++ b/apps/hestia/src/components/rewards/template.tsx
@@ -20,7 +20,7 @@ import { Help } from "./Help";
 import { Info } from "./info";
 
 import { Footer, Header } from "@/components/ui";
-import { useSizeObserver, useTour } from "@/hooks";
+import { useSizeObserver } from "@/hooks";
 
 export function Template() {
   const [tab, setTab] = useState("0");
@@ -70,7 +70,6 @@ export function Template() {
   const { browserAccountPresent, extensionAccountPresent } =
     useConnectWalletProvider();
 
-  const { onOpenChange } = useTour();
   useEffect(() => {
     const epochsLength = epochs?.length || 0;
     if (epochs && epochs?.length > 2) {
@@ -223,7 +222,7 @@ export function Template() {
           </Fragment>
         )
       ) : (
-        <Footer onOpenChange={onOpenChange} ref={footerRef} />
+        <Footer ref={footerRef} />
       )}
     </div>
   );

--- a/apps/hestia/src/components/rewardsLanding/template.tsx
+++ b/apps/hestia/src/components/rewardsLanding/template.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { useResizeObserver } from "usehooks-ts";
-import { Fragment, useMemo, useRef } from "react";
+import { useMemo, useRef } from "react";
 import { useWindowSize } from "react-use";
-
-import { QuickStart } from "../ui/Footer/QuickStart";
 
 import { Info } from "./info";
 import { HowItWorks } from "./howItWorks";
@@ -19,7 +17,7 @@ export function Template() {
 
   const footerRef = useRef<HTMLDivElement | null>(null);
   const headerRef = useRef<HTMLDivElement | null>(null);
-  const { onOpenChange, open, onClose } = useTour();
+  const { onOpenChange } = useTour();
 
   const { height: footerHeight = 0 } = useResizeObserver({
     ref: footerRef,
@@ -28,28 +26,25 @@ export function Template() {
   const mobileView = useMemo(() => width <= 750, [width]);
 
   return (
-    <Fragment>
-      <QuickStart open={open} onOpenChange={onClose} />
-      <div
-        className="flex flex-1 flex-col bg-backgroundBase h-full"
-        vaul-drawer-wrapper=""
+    <div
+      className="flex flex-1 flex-col bg-backgroundBase h-full"
+      vaul-drawer-wrapper=""
+    >
+      <Header ref={headerRef} />
+      <main
+        className="flex flex-col flex-1 overflow-auto w-full max-w-[1100px] m-auto"
+        style={{
+          paddingBottom: `${footerHeight}px`,
+        }}
       >
-        <Header ref={headerRef} />
-        <main
-          className="flex flex-col flex-1 overflow-auto w-full max-w-[1100px] m-auto"
-          style={{
-            paddingBottom: `${footerHeight}px`,
-          }}
-        >
-          <Info />
-          <HowItWorks />
-          <Faq />
-          <CallToAction />
-        </main>
-        {!mobileView && (
-          <Footer onOpenChange={onOpenChange} marketsActive ref={footerRef} />
-        )}
-      </div>
-    </Fragment>
+        <Info />
+        <HowItWorks />
+        <Faq />
+        <CallToAction />
+      </main>
+      {!mobileView && (
+        <Footer onOpenChange={onOpenChange} marketsActive ref={footerRef} />
+      )}
+    </div>
   );
 }

--- a/apps/hestia/src/components/rewardsLanding/template.tsx
+++ b/apps/hestia/src/components/rewardsLanding/template.tsx
@@ -10,14 +10,12 @@ import { Faq } from "./faq";
 import { CallToAction } from "./callToAction";
 
 import { Footer, Header } from "@/components/ui";
-import { useTour } from "@/hooks";
 
 export function Template() {
   const { width } = useWindowSize();
 
   const footerRef = useRef<HTMLDivElement | null>(null);
   const headerRef = useRef<HTMLDivElement | null>(null);
-  const { onOpenChange } = useTour();
 
   const { height: footerHeight = 0 } = useResizeObserver({
     ref: footerRef,
@@ -42,9 +40,7 @@ export function Template() {
         <Faq />
         <CallToAction />
       </main>
-      {!mobileView && (
-        <Footer onOpenChange={onOpenChange} marketsActive ref={footerRef} />
-      )}
+      {!mobileView && <Footer marketsActive ref={footerRef} />}
     </div>
   );
 }

--- a/apps/hestia/src/components/rewardsPreview/template.tsx
+++ b/apps/hestia/src/components/rewardsPreview/template.tsx
@@ -17,13 +17,11 @@ import { Overview } from "./Overview";
 import { TableRewards } from "./TableRewards";
 
 import { Footer, Header } from "@/components/ui";
-import { useTour } from "@/hooks";
 
 export function Template({ id }: { id: string }) {
   const { width } = useWindowSize();
   const { list } = useMarkets();
   const currentMarket = getCurrentMarket(list, id);
-  const { onOpenChange } = useTour();
 
   const footerRef = useRef<HTMLDivElement | null>(null);
   const headerRef = useRef<HTMLDivElement | null>(null);
@@ -157,7 +155,7 @@ export function Template({ id }: { id: string }) {
           />
         </div>
       )}
-      <Footer onOpenChange={onOpenChange} ref={footerRef} />
+      <Footer ref={footerRef} />
     </div>
   );
 }

--- a/apps/hestia/src/components/trading/template.tsx
+++ b/apps/hestia/src/components/trading/template.tsx
@@ -19,7 +19,7 @@ import { ResponsiveAssetInfo } from "./AssetInfo/responsiveAssetInfo";
 
 import { ConnectTradingInteraction } from "@/components/ui/ConnectWalletInteraction/connectTradingInteraction";
 import { Footer, Header } from "@/components/ui";
-import { useSizeObserver, useTour } from "@/hooks";
+import { useSizeObserver } from "@/hooks";
 
 export function Template({ id }: { id: string }) {
   const [footerRef, footerHeight] = useSizeObserver();
@@ -29,7 +29,6 @@ export function Template({ id }: { id: string }) {
   const orderbookPanelRef = useRef<ImperativePanelHandle>(null);
 
   const { width } = useWindowSize();
-  const { onOpenChange } = useTour();
   const { list } = useMarkets();
   const currentMarket = getCurrentMarket(list, id);
 
@@ -179,11 +178,7 @@ export function Template({ id }: { id: string }) {
           market={currentMarket}
         />
       ) : (
-        <Footer
-          onOpenChange={() => onOpenChange(true)}
-          marketsActive
-          ref={footerRef}
-        />
+        <Footer marketsActive ref={footerRef} />
       )}
     </Fragment>
   );

--- a/apps/hestia/src/components/transactions/template.tsx
+++ b/apps/hestia/src/components/transactions/template.tsx
@@ -10,7 +10,6 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useConnectWalletProvider } from "@orderbook/core/providers/user/connectWalletProvider";
 
 import { ResponsiveProfile } from "../ui/Header/Profile/responsiveProfile";
-import { QuickStart } from "../ui/Footer/QuickStart";
 
 import { Help } from "./Help";
 import { TransferHistory } from "./Transfer";
@@ -27,7 +26,7 @@ export function Template() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { width } = useWindowSize();
-  const { onOpenChange, open, onClose } = useTour();
+  const { onOpenChange } = useTour();
 
   const headerRef = useRef<HTMLDivElement | null>(null);
   const helpRef = useRef<HTMLDivElement | null>(null);
@@ -82,7 +81,6 @@ export function Template() {
 
   return (
     <Fragment>
-      <QuickStart open={open} onOpenChange={onClose} />
       <ConnectTradingInteraction />
       <div
         className="flex flex-1 flex-col bg-backgroundBase h-full"

--- a/apps/hestia/src/components/transactions/template.tsx
+++ b/apps/hestia/src/components/transactions/template.tsx
@@ -20,13 +20,12 @@ import { TradeHistory } from "./TradeHistory";
 import { Footer, Header } from "@/components/ui";
 import { ConnectTradingInteraction } from "@/components/ui/ConnectWalletInteraction/connectTradingInteraction";
 import { ConnectAccountWrapper } from "@/components/ui/ReadyToUse";
-import { useSizeObserver, useTour } from "@/hooks";
+import { useSizeObserver } from "@/hooks";
 
 export function Template() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { width } = useWindowSize();
-  const { onOpenChange } = useTour();
 
   const headerRef = useRef<HTMLDivElement | null>(null);
   const helpRef = useRef<HTMLDivElement | null>(null);
@@ -205,9 +204,7 @@ export function Template() {
               />
             </div>
           )}
-          {!mobileView && (
-            <Footer onOpenChange={onOpenChange} marketsActive ref={footerRef} />
-          )}
+          {!mobileView && <Footer marketsActive ref={footerRef} />}
         </Tabs>
       </div>
     </Fragment>

--- a/apps/hestia/src/components/transfer/template.tsx
+++ b/apps/hestia/src/components/transfer/template.tsx
@@ -18,7 +18,7 @@ import { History } from "./History";
 import { ReadyToClaim } from "./ReadyToClaim";
 
 import { Footer, Header } from "@/components/ui";
-import { useTour, useTransfer } from "@/hooks";
+import { useTransfer } from "@/hooks";
 import { defaultConfig } from "@/config";
 
 const sleep = async (ms: number) =>
@@ -28,7 +28,6 @@ export function Template() {
   const router = useRouter();
   const pathname = usePathname();
   const { width } = useWindowSize();
-  const { onOpenChange } = useTour();
 
   const headerRef = useRef<HTMLDivElement | null>(null);
   const helpRef = useRef<HTMLDivElement | null>(null);
@@ -201,7 +200,7 @@ export function Template() {
             />
           </div>
         )}
-        {!mobileView && <Footer onOpenChange={onOpenChange} ref={footerRef} />}
+        {!mobileView && <Footer ref={footerRef} />}
       </div>
     </Fragment>
   );

--- a/apps/hestia/src/components/transfer/template.tsx
+++ b/apps/hestia/src/components/transfer/template.tsx
@@ -10,7 +10,6 @@ import { useResizeObserver, useWindowSize } from "usehooks-ts";
 
 import { ConnectTradingInteraction } from "../ui/ConnectWalletInteraction/connectTradingInteraction";
 import { ResponsiveProfile } from "../ui/Header/Profile/responsiveProfile";
-import { QuickStart } from "../ui/Footer/QuickStart";
 
 import { Help } from "./Help";
 import { SelectAsset } from "./SelectAsset";
@@ -29,7 +28,7 @@ export function Template() {
   const router = useRouter();
   const pathname = usePathname();
   const { width } = useWindowSize();
-  const { onOpenChange, open, onClose } = useTour();
+  const { onOpenChange } = useTour();
 
   const headerRef = useRef<HTMLDivElement | null>(null);
   const helpRef = useRef<HTMLDivElement | null>(null);
@@ -106,7 +105,6 @@ export function Template() {
 
   return (
     <Fragment>
-      <QuickStart open={open} onOpenChange={onClose} />
       <ConnectTradingInteraction />
       <SelectAsset
         open={assetsInteraction}

--- a/apps/hestia/src/components/ui/Footer/index.tsx
+++ b/apps/hestia/src/components/ui/Footer/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, Fragment, SetStateAction, forwardRef, useMemo } from "react";
+import { Fragment, forwardRef, useMemo } from "react";
 import { Dropdown, Typography } from "@polkadex/ux";
 import { useNativeApi } from "@orderbook/core/providers/public/nativeApi";
 import {
@@ -7,92 +7,82 @@ import {
 } from "@orderbook/core/providers/public/settings";
 import classNames from "classnames";
 import Link from "next/link";
-import { RiLifebuoyLine, RiMessage3Line } from "@remixicon/react";
+import { RiLifebuoyLine } from "@remixicon/react";
 import { useWindowSize } from "usehooks-ts";
 
 import { Markets } from "./markets";
 
-export const Footer = forwardRef<
-  HTMLDivElement,
-  {
-    marketsActive?: boolean;
-    onOpenChange: Dispatch<SetStateAction<boolean>>;
-  }
->(({ marketsActive = false, onOpenChange }, ref) => {
-  const { marketCarousel, onChangeMarketCarousel } = useSettingsProvider();
+export const Footer = forwardRef<HTMLDivElement, { marketsActive?: boolean }>(
+  ({ marketsActive = false }, ref) => {
+    const { marketCarousel, onChangeMarketCarousel } = useSettingsProvider();
 
-  const { width } = useWindowSize();
-  const { connected } = useNativeApi();
+    const { width } = useWindowSize();
+    const { connected } = useNativeApi();
 
-  const mobileView = useMemo(() => width <= 640, [width]);
+    const mobileView = useMemo(() => width <= 640, [width]);
 
-  return (
-    <Fragment>
-      <footer
-        ref={ref}
-        className={classNames(
-          "md:grid md:grid-flow-col-dense md:grid-cols-2 border-y border-primary w-full bg-level-0",
-          !mobileView && "fixed bottom-0 left-0"
-        )}
-      >
-        {marketsActive ? (
-          <div className="col-span-4 flex flex-auto">
-            <div className="border-r bg-level-2 px-2 border-secondary">
-              <Dropdown>
-                <Dropdown.Trigger className="items-center inline-flex opacity-50 transition-opacity ease-out duration-300 hover:opacity-100 w-full">
-                  <Typography.Text>{marketCarousel}</Typography.Text>
-                  <Dropdown.Icon />
-                </Dropdown.Trigger>
-                <Dropdown.Content>
-                  {marketCarouselValues.map((value, i) => (
-                    <Dropdown.Item
-                      onClick={() => onChangeMarketCarousel(value)}
-                      key={i}
-                    >
-                      <Typography.Text className="text-left block w-full">
-                        {value}
-                      </Typography.Text>
-                    </Dropdown.Item>
-                  ))}
-                </Dropdown.Content>
-              </Dropdown>
+    return (
+      <Fragment>
+        <footer
+          ref={ref}
+          className={classNames(
+            "md:grid md:grid-flow-col-dense md:grid-cols-2 border-y border-primary w-full bg-level-0",
+            !mobileView && "fixed bottom-0 left-0"
+          )}
+        >
+          {marketsActive ? (
+            <div className="col-span-4 flex flex-auto">
+              <div className="border-r bg-level-2 px-2 border-secondary">
+                <Dropdown>
+                  <Dropdown.Trigger className="items-center inline-flex opacity-50 transition-opacity ease-out duration-300 hover:opacity-100 w-full">
+                    <Typography.Text>{marketCarousel}</Typography.Text>
+                    <Dropdown.Icon />
+                  </Dropdown.Trigger>
+                  <Dropdown.Content>
+                    {marketCarouselValues.map((value, i) => (
+                      <Dropdown.Item
+                        onClick={() => onChangeMarketCarousel(value)}
+                        key={i}
+                      >
+                        <Typography.Text className="text-left block w-full">
+                          {value}
+                        </Typography.Text>
+                      </Dropdown.Item>
+                    ))}
+                  </Dropdown.Content>
+                </Dropdown>
+              </div>
+              <Markets favorite={marketCarousel === "Favourite"} />
             </div>
-            <Markets favorite={marketCarousel === "Favourite"} />
-          </div>
-        ) : (
-          <div />
-        )}
-        <div className="col-span-1 flex flex-1 gap-3 bg-level-1 px-2 py border-l border-secondary w-full justify-end">
-          <div className="flex items-center gap-1">
-            <div
-              className={classNames(
-                "w-2 h-2 rounded-full ",
-                connected ? "bg-success-base" : "bg-attention-base"
-              )}
-            />
-            <Typography.Text>
-              {connected ? "Connected" : "Connecting"}
+          ) : (
+            <div />
+          )}
+          <div className="col-span-1 flex flex-1 gap-3 bg-level-1 px-2 py border-l border-secondary w-full justify-end">
+            <div className="flex items-center gap-1">
+              <div
+                className={classNames(
+                  "w-2 h-2 rounded-full ",
+                  connected ? "bg-success-base" : "bg-attention-base"
+                )}
+              />
+              <Typography.Text>
+                {connected ? "Connected" : "Connecting"}
+              </Typography.Text>
+            </div>
+            <Typography.Text appearance="primary">
+              <Link
+                href="https://discord.com/invite/Uvua83QAzk"
+                target="_blank"
+              >
+                <RiLifebuoyLine className="h-3 w-3 inline-block mr-1" />
+                Help & Support
+              </Link>
             </Typography.Text>
           </div>
-          <Typography.Text
-            className="cursor-pointer"
-            appearance="primary"
-            onClick={() => onOpenChange(true)}
-          >
-            <RiMessage3Line className="h-3 w-3 inline-block mr-1" />
-            Quick Start
-          </Typography.Text>
-
-          <Typography.Text appearance="primary">
-            <Link href="https://discord.com/invite/Uvua83QAzk" target="_blank">
-              <RiLifebuoyLine className="h-3 w-3 inline-block mr-1" />
-              Help & Support
-            </Link>
-          </Typography.Text>
-        </div>
-      </footer>
-    </Fragment>
-  );
-});
+        </footer>
+      </Fragment>
+    );
+  }
+);
 
 Footer.displayName = "Footer";


### PR DESCRIPTION
## Description

This pull request addresses the need to remove the QuickStart feature from all pages and disable the "Convert Small Balance to PDEx" button on the balances page.

## Changes Made:

- [x] Removed QuickStart component from all pages.
- [x] Disabled the "Convert Small Balance to PDEx" button on the balances page.

## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.


Close: https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues/1224