### PR TITLE
Validation Check for Imported Trading Account from Google Drive

### DIFF
--- a/apps/hestia/src/components/ui/ConnectWallet/connectTradingAccount.tsx
+++ b/apps/hestia/src/components/ui/ConnectWallet/connectTradingAccount.tsx
@@ -93,7 +93,14 @@ export const ConnectTradingAccount = ({
                     <Skeleton loading className="min-h-14 rounded-sm" />
                   )}
                   {attentionAccounts?.map((e) => (
-                    <AttentionAccountCard key={e.address} account={e} />
+                    <AttentionAccountCard
+                      key={e.address}
+                      account={e}
+                      onRemove={() => {
+                        onTempBrowserAccount(e);
+                        onRemoveCallback();
+                      }}
+                    />
                   ))}
                   {accounts?.map((value, i) => {
                     const externalStored = isStoreInGoogleDrive(value.address);


### PR DESCRIPTION
## Description

This pull request addresses the issue where users are able to import trading accounts from Google Drive even after they have been removed from the blockchain. The PR introduces a validation check to ensure that imported trading accounts are still valid for use. If an imported trading account is found to be invalid, users will be presented with the option to remove it from Google Drive.

## Changes:

- [x] fix: Added validation check for imported trading accounts from Google Drive.

## Screenshots / Screencasts

https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/12574469/5a337bf3-9f17-4eed-9716-5003c6e303ee


## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.


Close: https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues/1230
