### PR TITLE
fix: condition for history page

### DIFF
--- a/apps/hestia/src/components/transactions/template.tsx
+++ b/apps/hestia/src/components/transactions/template.tsx
@@ -72,7 +72,7 @@ export function Template() {
     [headerHeight, overviewHeight, helpHeight, tableRowsHeight, footerHeight]
   );
   const {
-    selectedAddresses: { mainAddress, tradeAddress },
+    selectedAddresses: { mainAddress },
   } = useProfile();
   const mobileView = useMemo(() => width <= 640, [width]);
   const { browserAccountPresent, extensionAccountPresent } =
@@ -158,36 +158,36 @@ export function Template() {
                 )}
               </Tabs.Content>
               <Tabs.Content value="openOrders" className="flex-1 flex">
-                {tradeAddress?.length ? (
+                {mainAddress?.length ? (
                   <OpenOrders
                     ref={tableRowsRef}
                     maxHeight={maxHeight}
                     searchTerm={searchTerm}
                   />
                 ) : (
-                  <ConnectAccountWrapper />
+                  <ConnectAccountWrapper funding />
                 )}
               </Tabs.Content>
               <Tabs.Content value="orderHistory" className="flex-1 flex">
-                {tradeAddress?.length ? (
+                {mainAddress?.length ? (
                   <OrderHistory
                     ref={tableRowsRef}
                     maxHeight={maxHeight}
                     searchTerm={searchTerm}
                   />
                 ) : (
-                  <ConnectAccountWrapper />
+                  <ConnectAccountWrapper funding />
                 )}
               </Tabs.Content>
               <Tabs.Content value="tradeHistory" className="flex-1 flex">
-                {tradeAddress?.length ? (
+                {mainAddress?.length ? (
                   <TradeHistory
                     ref={tableRowsRef}
                     maxHeight={maxHeight}
                     searchTerm={searchTerm}
                   />
                 ) : (
-                  <ConnectAccountWrapper />
+                  <ConnectAccountWrapper funding />
                 )}
               </Tabs.Content>
               <Help ref={helpRef} />

--- a/packages/core/src/hooks/useCancelAllOrders.ts
+++ b/packages/core/src/hooks/useCancelAllOrders.ts
@@ -23,6 +23,8 @@ export const useCancelAllOrders = () => {
       if (!api?.isConnected)
         throw new Error("You are not connected to blockchain");
 
+      if (!tradeAddress) throw new Error("No trading account selected");
+
       const keyringPair = wallet.getPair(tradeAddress);
       if (!isValidAddress(tradeAddress) || !keyringPair)
         throw new Error("Invalid Trading Account");

--- a/packages/core/src/hooks/useCancelOrder.ts
+++ b/packages/core/src/hooks/useCancelOrder.ts
@@ -30,6 +30,8 @@ export const useCancelOrder = () => {
       if (!api?.isConnected)
         throw new Error("You are not connected to blockchain");
 
+      if (!tradeAddress) throw new Error("No trading account selected");
+
       const keyringPair = wallet.getPair(tradeAddress);
       if (!isValidAddress(tradeAddress) || !keyringPair)
         throw new Error("Invalid Trading Account");


### PR DESCRIPTION
## Description

As, History page shows the data based on Selected funding account. but if user didn't select his funding account, it still asks user to connect trading account. Ideally, It should ask user to connect funding account.

https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/4eb62ebf-dff9-49a6-9401-6ee73bdef53a

## Screenshots / Screencasts

https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/33935581-ae11-4a06-93bb-e73513e7679c

## Checklist

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
