### PR TITLE
Add link to analytics platform

### DIFF
--- a/apps/hestia/src/components/ui/Header/index.tsx
+++ b/apps/hestia/src/components/ui/Header/index.tsx
@@ -105,6 +105,10 @@ export const Header = forwardRef<HTMLDivElement>((_, ref) => {
                   href: "https://github.com/Polkadex-Substrate/Docs/blob/master/Polkadex_Data_Retention_Policy.pdf",
                   label: "Data Retention Policy",
                 },
+                {
+                  href: "https://pdexanalytics.com",
+                  label: "Analytics",
+                },
               ]}
             >
               More

--- a/apps/hestia/src/components/ui/Header/responsiveMenuModal.tsx
+++ b/apps/hestia/src/components/ui/Header/responsiveMenuModal.tsx
@@ -116,6 +116,10 @@ export const ResponsiveMenuModal = ({
                         href: "https://github.com/Polkadex-Substrate/Docs/blob/master/Polkadex_Data_Retention_Policy.pdf",
                         label: "Data Retention Policy",
                       },
+                      {
+                        href: "https://pdexanalytics.com",
+                        label: "Analytics",
+                      },
                     ]}
                   >
                     More


### PR DESCRIPTION
## Description

Added a link to the analytics platform from the orderbook

## Changes Made

Added a link to the analytics platform in the header to these files:

apps/hestia/src/components/ui/Header/index.tsx
apps/hestia/src/components/ui/Header/responsiveMenuModal.tsx

## How to Test

See new Analytics link in the header under "More".

## Screenshots / Screencasts

![image](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/6218678/2978da9b-b40a-407f-ac82-095d1df2cabe)

## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [ ] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [ X] I have tested these changes thoroughly.
- [ ] I have requested a review from at least one other contributor.
