### PR TITLE
Refactor Cross Chain Logic

### DIFF
--- a/apps/hestia/package.json
+++ b/apps/hestia/package.json
@@ -23,7 +23,7 @@
     "@polkadex/numericals": "^0.3.0",
     "@polkadex/polkadex-api": "^3.2.0",
     "@polkadex/subscan": "^1.1.61",
-    "@polkadex/thea": "^5.0.0",
+    "@polkadex/thea": "^5.2.0",
     "@polkadex/ux": "^6.23.0",
     "@polkadex/react-providers": "^2.2.0",
     "@polkadex/types": "^1.2.2",

--- a/apps/hestia/package.json
+++ b/apps/hestia/package.json
@@ -23,7 +23,7 @@
     "@polkadex/numericals": "^0.3.0",
     "@polkadex/polkadex-api": "^3.2.0",
     "@polkadex/subscan": "^1.1.61",
-    "@polkadex/thea": "^5.2.0",
+    "@polkadex/thea": "^5.3.0",
     "@polkadex/ux": "^6.23.0",
     "@polkadex/react-providers": "^2.2.0",
     "@polkadex/types": "^1.2.2",

--- a/apps/hestia/src/components/balances/Overview/index.tsx
+++ b/apps/hestia/src/components/balances/Overview/index.tsx
@@ -44,17 +44,12 @@ export const Overview = () => {
         </HoverCard>
       </div>
       <div className="flex items-center gap-2 sm:max-w-[25rem] w-full flex-wrap">
-        <OverviewCard
-          icon="RiSkipDownLine"
-          target="_blank"
-          href="https://thea.polkadex.trade/"
-        >
+        <OverviewCard icon="RiSkipDownLine" href="/thea">
           Deposit
         </OverviewCard>
         <OverviewCard
           icon="RiSkipUpLine"
-          target="_blank"
-          href="https://thea.polkadex.trade/withdraw"
+          href="/thea?from=Polkadex&to=Polkadot"
         >
           Withdraw
         </OverviewCard>

--- a/apps/hestia/src/components/balances/Table/columns.tsx
+++ b/apps/hestia/src/components/balances/Table/columns.tsx
@@ -87,15 +87,19 @@ export const columns = [
       return (
         <ActionsCard
           withdrawLink={{
-            pathname: "https://thea.polkadex.trade/withdraw",
-            query: chainName && {
-              chain: encodeURIComponent(chainName),
+            pathname: "/thea",
+            query: {
+              from: "Polkadex",
+              to: chainName,
+              asset: e.getValue().ticker,
             },
           }}
           depositLink={{
-            pathname: "https://thea.polkadex.trade/",
-            query: chainName && {
-              chain: encodeURIComponent(chainName),
+            pathname: "/thea",
+            query: {
+              from: chainName,
+              to: "Polkadex",
+              asset: e.getValue().ticker,
             },
           }}
           tradeLink={`/trading/${e.getValue().ticker}`}

--- a/apps/hestia/src/components/balances/Table/responsiveTable.tsx
+++ b/apps/hestia/src/components/balances/Table/responsiveTable.tsx
@@ -46,9 +46,11 @@ export const ResponsiveTable = ({
         <Button.Solid appearance="secondary" asChild>
           <Link
             href={{
-              pathname: "https://thea.polkadex.trade/withdraw",
-              query: chainName && {
-                chain: encodeURIComponent(chainName),
+              pathname: "/thea",
+              query: {
+                from: "Polkadex",
+                to: chainName,
+                asset: ticker,
               },
             }}
             target="_blank"
@@ -59,9 +61,11 @@ export const ResponsiveTable = ({
         <Button.Solid appearance="secondary" asChild>
           <Link
             href={{
-              pathname: "https://thea.polkadex.trade/",
-              query: chainName && {
-                chain: encodeURIComponent(chainName),
+              pathname: "/thea",
+              query: {
+                from: chainName,
+                to: "Polkadex",
+                asset: ticker,
               },
             }}
             target="_blank"

--- a/apps/hestia/src/components/landing/footer.tsx
+++ b/apps/hestia/src/components/landing/footer.tsx
@@ -108,7 +108,7 @@ const data = [
       },
       {
         title: "THEA Crosschain",
-        href: "https://thea.polkadex.trade",
+        href: "https://orderbook.polkadex.trade/thea",
         target: "_blank",
       },
     ],

--- a/apps/hestia/src/components/thea/Form/index.tsx
+++ b/apps/hestia/src/components/thea/Form/index.tsx
@@ -42,7 +42,7 @@ export const Form = () => {
     sourceChain,
     onSelectSourceChain,
     destinationChain,
-    setDestinationChain,
+    onSelectDestinationChain,
     sourceAccount,
     setSourceAccount,
     destinationAccount,
@@ -61,9 +61,9 @@ export const Form = () => {
   const { push } = useRouter();
 
   const onSwitchChain = () => {
-    if (!destinationChain) return;
+    if (!destinationChain || !sourceChain) return;
     onSelectSourceChain(destinationChain);
-    setDestinationChain(sourceChain);
+    onSelectDestinationChain(sourceChain);
     const data = [
       { name: "from", value: destinationChain?.name },
       { name: "to", value: sourceChain?.name },
@@ -248,7 +248,7 @@ export const Form = () => {
                           icon={e.logo}
                           value={e.name}
                           side="to"
-                          onSelect={() => setDestinationChain(e)}
+                          onSelect={() => onSelectDestinationChain(e)}
                         />
                       );
                     })}

--- a/apps/hestia/src/components/thea/Form/index.tsx
+++ b/apps/hestia/src/components/thea/Form/index.tsx
@@ -78,7 +78,11 @@ export const Form = () => {
     resetForm,
   } = useFormik({
     initialValues,
-    validationSchema: bridgeValidations(min?.amount, max?.amount),
+    validationSchema: bridgeValidations(
+      min?.amount,
+      max?.amount,
+      selectedAssetBalance
+    ),
     onSubmit: () => setOpenFeeModal(true),
   });
   const disabled = useMemo(

--- a/apps/hestia/src/components/thea/Form/index.tsx
+++ b/apps/hestia/src/components/thea/Form/index.tsx
@@ -15,7 +15,7 @@ import {
   RiInformationFill,
   RiWalletLine,
 } from "@remixicon/react";
-import { Fragment, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { useTheaProvider } from "@orderbook/core/providers";
 import { usePathname, useSearchParams, useRouter } from "next/navigation";
 import { useFormik } from "formik";
@@ -61,18 +61,8 @@ export const Form = () => {
   const pathname = usePathname();
   const { push } = useRouter();
 
-  const onSwitchChain = async () => {
+  const onSwitchChain = () => {
     onSwitch();
-    const data = [
-      { name: "from", value: destinationChain?.name },
-      { name: "to", value: sourceChain?.name },
-    ];
-    createQueryString({
-      data,
-      pathname,
-      searchParams,
-      push,
-    });
     resetForm();
   };
 
@@ -143,6 +133,27 @@ export const Form = () => {
     sourceFee?.ticker,
   ]);
 
+  useEffect(() => {
+    const data = [
+      { name: "from", value: sourceChain?.name },
+      { name: "to", value: destinationChain?.name },
+      { name: "asset", value: selectedAsset?.ticker },
+    ];
+    createQueryString({
+      data,
+      pathname,
+      searchParams,
+      push,
+    });
+  }, [
+    destinationChain?.name,
+    pathname,
+    push,
+    searchParams,
+    selectedAsset?.ticker,
+    sourceChain?.name,
+  ]);
+
   return (
     <Fragment>
       <ConfirmTransaction
@@ -182,7 +193,6 @@ export const Form = () => {
                           key={e.genesis}
                           icon={e.logo}
                           value={e.name}
-                          side="from"
                           onSelect={() => onSelectSourceChain(e)}
                         />
                       );
@@ -241,7 +251,6 @@ export const Form = () => {
                           key={e.genesis}
                           icon={e.logo}
                           value={e.name}
-                          side="to"
                           onSelect={() => onSelectDestinationChain(e)}
                         />
                       );

--- a/apps/hestia/src/components/thea/Form/index.tsx
+++ b/apps/hestia/src/components/thea/Form/index.tsx
@@ -355,7 +355,7 @@ export const Form = () => {
                 <Button.Outline
                   type="button"
                   appearance="secondary"
-                  className="gap-1 px-2 py-7 justify-between"
+                  className="gap-1 px-2 justify-between h-full"
                   onClick={() => setOpenAsset(true)}
                   disabled={!sourceChain || !destinationChain}
                 >

--- a/apps/hestia/src/components/thea/Form/index.tsx
+++ b/apps/hestia/src/components/thea/Form/index.tsx
@@ -54,16 +54,15 @@ export const Form = () => {
     selectedAssetBalance,
     supportedSourceChains,
     supportedDestinationChains,
+    onSwitchChain: onSwitch,
   } = useTheaProvider();
   const { destinationFee, sourceFee, max, min } = transferConfig ?? {};
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const { push } = useRouter();
 
-  const onSwitchChain = () => {
-    if (!destinationChain || !sourceChain) return;
-    onSelectSourceChain(destinationChain);
-    onSelectDestinationChain(sourceChain);
+  const onSwitchChain = async () => {
+    onSwitch();
     const data = [
       { name: "from", value: destinationChain?.name },
       { name: "to", value: sourceChain?.name },

--- a/apps/hestia/src/components/thea/Form/index.tsx
+++ b/apps/hestia/src/components/thea/Form/index.tsx
@@ -52,7 +52,8 @@ export const Form = () => {
     sourceBalancesLoading,
     transferConfig,
     selectedAssetBalance,
-    chains,
+    supportedSourceChains,
+    supportedDestinationChains,
   } = useTheaProvider();
   const { destinationFee, sourceFee, max, min } = transferConfig ?? {};
   const searchParams = useSearchParams();
@@ -180,15 +181,7 @@ export const Form = () => {
                     name={sourceChain?.name}
                     icon={sourceChain?.logo}
                   >
-                    {chains.map((e) => {
-                      const id = e.genesis;
-                      if (
-                        [
-                          sourceChain?.genesis,
-                          destinationChain?.genesis,
-                        ].includes(id)
-                      )
-                        return null;
+                    {supportedSourceChains.map((e) => {
                       return (
                         <SelectNetwork.Card
                           key={e.genesis}
@@ -247,15 +240,7 @@ export const Form = () => {
                     name={destinationChain?.name}
                     icon={destinationChain?.logo}
                   >
-                    {chains.map((e) => {
-                      const id = e.genesis;
-                      if (
-                        [
-                          sourceChain?.genesis,
-                          destinationChain?.genesis,
-                        ].includes(id)
-                      )
-                        return null;
+                    {supportedDestinationChains.map((e) => {
                       return (
                         <SelectNetwork.Card
                           key={e.genesis}

--- a/apps/hestia/src/components/thea/Form/index.tsx
+++ b/apps/hestia/src/components/thea/Form/index.tsx
@@ -40,7 +40,7 @@ export const Form = () => {
 
   const {
     sourceChain,
-    setSourceChain,
+    onChangeSourceChain,
     destinationChain,
     setDestinationChain,
     sourceAccount,
@@ -61,7 +61,8 @@ export const Form = () => {
   const { push } = useRouter();
 
   const onSwitchChain = () => {
-    setSourceChain(destinationChain);
+    if (!destinationChain) return;
+    onChangeSourceChain(destinationChain);
     setDestinationChain(sourceChain);
     const data = [
       { name: "from", value: destinationChain?.name },
@@ -188,7 +189,7 @@ export const Form = () => {
                           icon={e.logo}
                           value={e.name}
                           side="from"
-                          onSelect={() => setSourceChain(e)}
+                          onSelect={() => onChangeSourceChain(e)}
                         />
                       );
                     })}

--- a/apps/hestia/src/components/thea/Form/index.tsx
+++ b/apps/hestia/src/components/thea/Form/index.tsx
@@ -116,11 +116,6 @@ export const Form = () => {
     setFieldValue("amount", formattedAmount);
   };
 
-  const availableValue = useMemo(
-    () => formatAmount(transferConfig?.max.amount ?? 0),
-    [transferConfig?.max.amount]
-  );
-
   const balanceAmount = useMemo(
     () => formatAmount(selectedAssetBalance),
     [selectedAssetBalance]
@@ -271,7 +266,7 @@ export const Form = () => {
                   >
                     <RiInformationFill className="w-3 h-3 text-actionInput" />
                     <Typography.Text size="xs" appearance="primary">
-                      Available: {availableValue} {selectedAsset?.ticker}
+                      Available: {selectedAssetBalance} {selectedAsset?.ticker}
                     </Typography.Text>
                     <HoverInformation.Arrow />
                   </HoverInformation.Trigger>
@@ -298,7 +293,7 @@ export const Form = () => {
                       label="Available"
                       loading={sourceBalancesLoading}
                     >
-                      {availableValue} {selectedAsset?.ticker}
+                      {selectedAssetBalance} {selectedAsset?.ticker}
                     </ResponsiveCard>
                   </HoverInformation.Content>
                 </HoverInformation>

--- a/apps/hestia/src/components/thea/Form/index.tsx
+++ b/apps/hestia/src/components/thea/Form/index.tsx
@@ -13,6 +13,7 @@ import {
   RiArrowDownSLine,
   RiArrowLeftRightLine,
   RiInformationFill,
+  RiLoader2Line,
   RiWalletLine,
 } from "@remixicon/react";
 import { Fragment, useEffect, useMemo, useState } from "react";
@@ -364,9 +365,20 @@ export const Form = () => {
             </div>
           </div>
         </div>
-        <Button.Solid className="w-full py-5" size="md" disabled={disabled}>
-          Bridge
-        </Button.Solid>
+        {transferConfigLoading ? (
+          <Button.Solid
+            className="w-full py-5 flex items-center gap-1 opacity-60"
+            size="md"
+            disabled
+          >
+            <RiLoader2Line className="w-5 h-5 animate-spin" />
+            Connecting...
+          </Button.Solid>
+        ) : (
+          <Button.Solid className="w-full py-5" size="md" disabled={disabled}>
+            Bridge
+          </Button.Solid>
+        )}
       </form>
     </Fragment>
   );

--- a/apps/hestia/src/components/thea/Form/index.tsx
+++ b/apps/hestia/src/components/thea/Form/index.tsx
@@ -131,9 +131,9 @@ export const Form = () => {
     const sourceValue = sourceFee?.amount;
 
     return [
-      destValue ? `~${formatAmount(destValue)}` : "Ø",
+      destValue ? `~ ${formatAmount(destValue)}` : "Ø",
       destValue ? destinationFee?.ticker : "",
-      sourceValue ? `~${formatAmount(sourceValue)}` : "Ø",
+      sourceValue ? `~ ${formatAmount(sourceValue)}` : "Ø",
       sourceValue ? sourceFee?.ticker : "",
     ];
   }, [
@@ -266,7 +266,7 @@ export const Form = () => {
                   >
                     <RiInformationFill className="w-3 h-3 text-actionInput" />
                     <Typography.Text size="xs" appearance="primary">
-                      Available: {selectedAssetBalance} {selectedAsset?.ticker}
+                      Available: {balanceAmount} {selectedAsset?.ticker}
                     </Typography.Text>
                     <HoverInformation.Arrow />
                   </HoverInformation.Trigger>
@@ -284,16 +284,10 @@ export const Form = () => {
                       {destinationFeeAmount} {destinationFeeTicker}
                     </ResponsiveCard>
                     <ResponsiveCard
-                      label="Balance"
-                      loading={sourceBalancesLoading}
-                    >
-                      {balanceAmount} {selectedAsset?.ticker}
-                    </ResponsiveCard>
-                    <ResponsiveCard
                       label="Available"
                       loading={sourceBalancesLoading}
                     >
-                      {selectedAssetBalance} {selectedAsset?.ticker}
+                      {balanceAmount} {selectedAsset?.ticker}
                     </ResponsiveCard>
                   </HoverInformation.Content>
                 </HoverInformation>

--- a/apps/hestia/src/components/thea/Form/index.tsx
+++ b/apps/hestia/src/components/thea/Form/index.tsx
@@ -40,7 +40,7 @@ export const Form = () => {
 
   const {
     sourceChain,
-    onChangeSourceChain,
+    onSelectSourceChain,
     destinationChain,
     setDestinationChain,
     sourceAccount,
@@ -62,7 +62,7 @@ export const Form = () => {
 
   const onSwitchChain = () => {
     if (!destinationChain) return;
-    onChangeSourceChain(destinationChain);
+    onSelectSourceChain(destinationChain);
     setDestinationChain(sourceChain);
     const data = [
       { name: "from", value: destinationChain?.name },
@@ -189,7 +189,7 @@ export const Form = () => {
                           icon={e.logo}
                           value={e.name}
                           side="from"
-                          onSelect={() => onChangeSourceChain(e)}
+                          onSelect={() => onSelectSourceChain(e)}
                         />
                       );
                     })}

--- a/apps/hestia/src/components/thea/Form/selectNetwork.tsx
+++ b/apps/hestia/src/components/thea/Form/selectNetwork.tsx
@@ -40,8 +40,9 @@ const SelectNetwork = ({
         </Button.Outline>
       </Dropdown.Trigger>
       <Dropdown.Content
-        className="max-h-[240px] hover:overflow-auto overflow-hidden"
-        style={{ minWidth: bounds.width }}
+        className="max-h-[250px] hover:overflow-auto overflow-hidden"
+        style={{ minWidth: bounds.width + 20 }}
+        sideOffset={0}
       >
         {children}
       </Dropdown.Content>

--- a/apps/hestia/src/components/thea/Form/selectNetwork.tsx
+++ b/apps/hestia/src/components/thea/Form/selectNetwork.tsx
@@ -1,11 +1,8 @@
 "use client";
 import { Typography, Chain, Button, Dropdown } from "@polkadex/ux";
 import { RiArrowDownSLine } from "@remixicon/react";
-import { usePathname, useSearchParams, useRouter } from "next/navigation";
 import { PropsWithChildren, useState } from "react";
 import { useMeasure } from "react-use";
-
-import { createQueryString } from "@/helpers";
 
 const SelectNetwork = ({
   name = "",
@@ -56,29 +53,13 @@ export const Card = ({
   icon,
   value,
   onSelect,
-  side,
 }: {
   icon: string;
   value: string;
-  side: "to" | "from";
   onSelect: () => void;
 }) => {
-  const searchParams = useSearchParams();
-  const pathname = usePathname();
-  const { push } = useRouter();
-
   return (
-    <Dropdown.Item
-      onSelect={() => {
-        onSelect();
-        createQueryString({
-          data: [{ name: side, value }],
-          pathname,
-          searchParams,
-          push,
-        });
-      }}
-    >
+    <Dropdown.Item onSelect={onSelect}>
       <div className="flex items-center gap-2 rounded-md w-full">
         <Chain name={icon} size="sm" />
         <Typography.Text>{value}</Typography.Text>

--- a/apps/hestia/src/components/thea/Help/card.tsx
+++ b/apps/hestia/src/components/thea/Help/card.tsx
@@ -20,17 +20,17 @@ export const Card = ({
       {children}
       <div className="flex flex-col gap-2 max-w-[25rem]">
         <div className="flex flex-col">
-          <div className="flex items-center gap-2">
-            <Typography.Paragraph
-              size="md"
-              className="font-medium leading-normal"
-            >
-              {title}
-            </Typography.Paragraph>
-            <Link href={href} target={target}>
-              <RiExternalLinkLine className="w-4 h-4 opacity-50" />
-            </Link>
-          </div>
+          <Link href={href} target={target}>
+            <div className="flex items-center gap-2">
+              <Typography.Paragraph
+                size="md"
+                className="font-medium leading-normal"
+              >
+                {title}
+              </Typography.Paragraph>
+              <RiExternalLinkLine className="w-3 h-3 opacity-50" />
+            </div>
+          </Link>
           {description && (
             <Typography.Paragraph appearance="primary" size="sm">
               {description}

--- a/apps/hestia/src/components/thea/Help/card.tsx
+++ b/apps/hestia/src/components/thea/Help/card.tsx
@@ -16,7 +16,7 @@ export const Card = ({
   target?: HTMLAttributeAnchorTarget;
 }>) => {
   return (
-    <div className="flex-1 w-full max-md:first:border-b md:h-full flex items-center max-lg:flex-row-reverse px-5 py-6 h-fit gap-4 border-secondary-base">
+    <div className="flex-1 w-full max-md:first:border-b md:h-full flex items-center px-5 py-6 h-fit gap-4 border-secondary-base">
       {children}
       <div className="flex flex-col gap-2 max-w-[25rem]">
         <div className="flex flex-col">

--- a/apps/hestia/src/components/thea/Help/card.tsx
+++ b/apps/hestia/src/components/thea/Help/card.tsx
@@ -1,36 +1,34 @@
 import { Typography } from "@polkadex/ux";
 import { RiExternalLinkLine } from "@remixicon/react";
-import Link from "next/link";
-import { HTMLAttributeAnchorTarget, PropsWithChildren } from "react";
+import { PropsWithChildren } from "react";
 
 export const Card = ({
   description,
   title,
   href,
-  target,
   children,
 }: PropsWithChildren<{
   description?: string;
   title: string;
   href: string;
-  target?: HTMLAttributeAnchorTarget;
 }>) => {
   return (
-    <div className="flex-1 w-full max-md:first:border-b md:h-full flex items-center px-5 py-6 h-fit gap-4 border-secondary-base">
+    <div
+      className="flex-1 w-full max-md:first:border-b md:h-full flex items-center px-2 py-6 h-fit gap-4 border-secondary-base cursor-pointer"
+      onClick={() => window.open(href)}
+    >
       {children}
       <div className="flex flex-col gap-2 max-w-[25rem]">
         <div className="flex flex-col">
-          <Link href={href} target={target}>
-            <div className="flex items-center gap-2">
-              <Typography.Paragraph
-                size="md"
-                className="font-medium leading-normal"
-              >
-                {title}
-              </Typography.Paragraph>
-              <RiExternalLinkLine className="w-3 h-3 opacity-50" />
-            </div>
-          </Link>
+          <div className="flex items-center gap-2">
+            <Typography.Paragraph
+              size="md"
+              className="font-medium leading-normal"
+            >
+              {title}
+            </Typography.Paragraph>
+            <RiExternalLinkLine className="w-3 h-3 opacity-50" />
+          </div>
           {description && (
             <Typography.Paragraph appearance="primary" size="sm">
               {description}

--- a/apps/hestia/src/components/thea/Help/card.tsx
+++ b/apps/hestia/src/components/thea/Help/card.tsx
@@ -20,14 +20,11 @@ export const Card = ({
       {children}
       <div className="flex flex-col gap-2 max-w-[25rem]">
         <div className="flex flex-col">
-          <div className="flex items-center gap-2">
-            <Typography.Paragraph
-              size="md"
-              className="font-medium leading-normal"
-            >
+          <div className="flex items-center gap-1">
+            <Typography.Text size="base" className="font-medium leading-normal">
               {title}
-            </Typography.Paragraph>
-            <RiExternalLinkLine className="w-3 h-3 opacity-50" />
+            </Typography.Text>
+            <RiExternalLinkLine className="w-4 h-4 opacity-50" />
           </div>
           {description && (
             <Typography.Paragraph appearance="primary" size="sm">

--- a/apps/hestia/src/components/thea/Help/card.tsx
+++ b/apps/hestia/src/components/thea/Help/card.tsx
@@ -1,24 +1,36 @@
 import { Typography } from "@polkadex/ux";
-import { PropsWithChildren } from "react";
+import { RiExternalLinkLine } from "@remixicon/react";
+import Link from "next/link";
+import { HTMLAttributeAnchorTarget, PropsWithChildren } from "react";
 
 export const Card = ({
   description,
   title,
+  href,
+  target,
   children,
 }: PropsWithChildren<{
   description?: string;
   title: string;
+  href: string;
+  target?: HTMLAttributeAnchorTarget;
 }>) => {
   return (
-    <div className="flex-1 w-full max-md:first:border-b md:h-full flex items-center justify-between px-5 py-6 h-fit gap-10 first:border-r border-secondary-base">
+    <div className="flex-1 w-full max-md:first:border-b md:h-full flex items-center max-lg:flex-row-reverse px-5 py-6 h-fit gap-4 border-secondary-base">
+      {children}
       <div className="flex flex-col gap-2 max-w-[25rem]">
         <div className="flex flex-col">
-          <Typography.Paragraph
-            size="md"
-            className="font-medium leading-normal"
-          >
-            {title}
-          </Typography.Paragraph>
+          <div className="flex items-center gap-2">
+            <Typography.Paragraph
+              size="md"
+              className="font-medium leading-normal"
+            >
+              {title}
+            </Typography.Paragraph>
+            <Link href={href} target={target}>
+              <RiExternalLinkLine className="w-4 h-4 opacity-50" />
+            </Link>
+          </div>
           {description && (
             <Typography.Paragraph appearance="primary" size="sm">
               {description}
@@ -26,7 +38,6 @@ export const Card = ({
           )}
         </div>
       </div>
-      {children}
     </div>
   );
 };

--- a/apps/hestia/src/components/thea/Help/card.tsx
+++ b/apps/hestia/src/components/thea/Help/card.tsx
@@ -1,38 +1,43 @@
 import { Typography } from "@polkadex/ux";
 import { RiExternalLinkLine } from "@remixicon/react";
-import { PropsWithChildren } from "react";
+import Link from "next/link";
+import { HTMLAttributeAnchorTarget, PropsWithChildren } from "react";
 
 export const Card = ({
   description,
   title,
   href,
+  target,
   children,
 }: PropsWithChildren<{
   description?: string;
   title: string;
   href: string;
+  target?: HTMLAttributeAnchorTarget;
 }>) => {
   return (
-    <div
-      className="flex-1 w-full max-md:first:border-b md:h-full flex items-center px-2 py-6 h-fit gap-4 border-secondary-base cursor-pointer"
-      onClick={() => window.open(href)}
-    >
-      {children}
-      <div className="flex flex-col gap-2 max-w-[25rem]">
-        <div className="flex flex-col">
-          <div className="flex items-center gap-1">
-            <Typography.Text size="base" className="font-medium leading-normal">
-              {title}
-            </Typography.Text>
-            <RiExternalLinkLine className="w-4 h-4 opacity-50" />
+    <Link href={href} target={target} className="w-full">
+      <div className="flex-1 w-full max-md:first:border-b md:h-full flex items-center px-2 py-6 h-fit gap-4 border-secondary-base">
+        {children}
+        <div className="flex flex-col gap-2 max-w-[25rem]">
+          <div className="flex flex-col">
+            <div className="flex items-center gap-1">
+              <Typography.Text
+                size="base"
+                className="font-medium leading-normal"
+              >
+                {title}
+              </Typography.Text>
+              <RiExternalLinkLine className="w-4 h-4 opacity-50" />
+            </div>
+            {description && (
+              <Typography.Paragraph appearance="primary" size="sm">
+                {description}
+              </Typography.Paragraph>
+            )}
           </div>
-          {description && (
-            <Typography.Paragraph appearance="primary" size="sm">
-              {description}
-            </Typography.Paragraph>
-          )}
         </div>
       </div>
-    </div>
+    </Link>
   );
 };

--- a/apps/hestia/src/components/thea/Help/index.tsx
+++ b/apps/hestia/src/components/thea/Help/index.tsx
@@ -10,7 +10,7 @@ export const Help = forwardRef<HTMLDivElement>((_, ref) => {
   return (
     <div
       ref={ref}
-      className="flex items-start max-md:flex-col max-md:gap-4 max-w-[900px] flex-1 mx-auto w-full mt-20 max-md:pb-4"
+      className="flex items-start max-md:flex-col max-md:gap-4 max-w-[900px] flex-1 mx-auto w-full mt-20 max-lg:pb-4"
     >
       <Card
         title="Cross-chain bridge transactions"
@@ -29,6 +29,7 @@ export const Help = forwardRef<HTMLDivElement>((_, ref) => {
         title="Having Trouble?"
         description="Feel free to get in touch."
         href="https://discord.gg/G4KMw2sGGe"
+        target="_blank"
       >
         <Button.Icon
           size="2sm"

--- a/apps/hestia/src/components/thea/Help/index.tsx
+++ b/apps/hestia/src/components/thea/Help/index.tsx
@@ -16,7 +16,6 @@ export const Help = forwardRef<HTMLDivElement>((_, ref) => {
         title="Cross-chain bridge transactions"
         description="Explore your transactions."
         href="/history?tab=crossChain"
-        target="_blank"
       >
         <Button.Icon
           size="2sm"
@@ -30,7 +29,6 @@ export const Help = forwardRef<HTMLDivElement>((_, ref) => {
         title="Having Trouble?"
         description="Feel free to get in touch."
         href="https://discord.gg/G4KMw2sGGe"
-        target="_blank"
       >
         <Button.Icon
           size="2sm"

--- a/apps/hestia/src/components/thea/Help/index.tsx
+++ b/apps/hestia/src/components/thea/Help/index.tsx
@@ -2,8 +2,7 @@
 
 import { Button } from "@polkadex/ux";
 import { forwardRef } from "react";
-import { RiExternalLinkLine } from "@remixicon/react";
-import Link from "next/link";
+import { RiBookOpenLine, RiFeedbackLine } from "@remixicon/react";
 
 import { Card } from "./card";
 
@@ -11,14 +10,34 @@ export const Help = forwardRef<HTMLDivElement>((_, ref) => {
   return (
     <div
       ref={ref}
-      className="flex items-center max-md:flex-col border-t border-primary"
+      className="flex items-start max-md:flex-col max-md:gap-4 max-w-[900px] flex-1 mx-auto w-full mt-20"
     >
-      <Card title="Having Trouble?" description="Feel free to get in touch.">
-        <Link href="https://discord.gg/G4KMw2sGGe" target="_blank">
-          <Button.Icon variant="outline">
-            <RiExternalLinkLine className="w-full h-full" />
-          </Button.Icon>
-        </Link>
+      <Card
+        title="Cross-chain bridge transactions"
+        description="Explore your transactions."
+        href="/history?tab=crossChain"
+      >
+        <Button.Icon
+          size="2sm"
+          appearance="secondary"
+          className="rounded-md bg-secondary-base"
+        >
+          <RiBookOpenLine className="w-full h-full" />
+        </Button.Icon>
+      </Card>
+      <Card
+        title="Having Trouble?"
+        description="Feel free to get in touch."
+        href="https://discord.gg/G4KMw2sGGe"
+        target="_blank"
+      >
+        <Button.Icon
+          size="2sm"
+          appearance="secondary"
+          className="rounded-md bg-secondary-base"
+        >
+          <RiFeedbackLine className="w-full h-full" />
+        </Button.Icon>
       </Card>
     </div>
   );

--- a/apps/hestia/src/components/thea/Help/index.tsx
+++ b/apps/hestia/src/components/thea/Help/index.tsx
@@ -20,7 +20,7 @@ export const Help = forwardRef<HTMLDivElement>((_, ref) => {
         <Button.Icon
           size="2sm"
           appearance="secondary"
-          className="rounded-md bg-secondary-base"
+          className="rounded-md bg-secondary-base pointer-events-none"
         >
           <RiBookOpenLine className="w-full h-full" />
         </Button.Icon>
@@ -34,7 +34,7 @@ export const Help = forwardRef<HTMLDivElement>((_, ref) => {
         <Button.Icon
           size="2sm"
           appearance="secondary"
-          className="rounded-md bg-secondary-base"
+          className="rounded-md bg-secondary-base pointer-events-none"
         >
           <RiFeedbackLine className="w-full h-full" />
         </Button.Icon>

--- a/apps/hestia/src/components/thea/Help/index.tsx
+++ b/apps/hestia/src/components/thea/Help/index.tsx
@@ -10,7 +10,7 @@ export const Help = forwardRef<HTMLDivElement>((_, ref) => {
   return (
     <div
       ref={ref}
-      className="flex items-start max-md:flex-col max-md:gap-4 max-w-[900px] flex-1 mx-auto w-full mt-20"
+      className="flex items-start max-md:flex-col max-md:gap-4 max-w-[900px] flex-1 mx-auto w-full mt-20 max-md:pb-4"
     >
       <Card
         title="Cross-chain bridge transactions"

--- a/apps/hestia/src/components/thea/Help/index.tsx
+++ b/apps/hestia/src/components/thea/Help/index.tsx
@@ -16,6 +16,7 @@ export const Help = forwardRef<HTMLDivElement>((_, ref) => {
         title="Cross-chain bridge transactions"
         description="Explore your transactions."
         href="/history?tab=crossChain"
+        target="_blank"
       >
         <Button.Icon
           size="2sm"

--- a/apps/hestia/src/components/thea/confirmTransaction.tsx
+++ b/apps/hestia/src/components/thea/confirmTransaction.tsx
@@ -91,12 +91,11 @@ export const ConfirmTransaction = ({
 
     if (!isPolkadexChain) return balance < (sourceFee?.amount ?? 0);
 
-    return balance < amount + autoSwapAmount;
+    return balance < (sourceFee?.amount ?? 0) + autoSwapAmount;
   }, [
     swapPrice,
     sourceFee,
     isPolkadexChain,
-    amount,
     showAutoSwap,
     sourceFeeBalance?.amount,
   ]);

--- a/apps/hestia/src/components/thea/confirmTransaction.tsx
+++ b/apps/hestia/src/components/thea/confirmTransaction.tsx
@@ -120,9 +120,9 @@ export const ConfirmTransaction = ({
     const sourceValue = sourceFee?.amount ?? 0;
     const autoswapAmount = showAutoSwap ? swapPrice : 0;
     return [
-      destValue ? `~${formatAmount(destValue)}` : "Ø",
+      destValue ? `~ ${formatAmount(destValue)}` : "Ø",
       destValue ? destinationFee?.ticker : "",
-      sourceValue ? `~${formatAmount(sourceValue)}` : "Ø",
+      sourceValue ? `~ ${formatAmount(sourceValue)}` : "Ø",
       sourceValue ? sourceFee?.ticker : "",
       formatAmount(sourceValue + destValue + autoswapAmount),
     ];
@@ -157,7 +157,10 @@ export const ConfirmTransaction = ({
                     {amount} {selectedAsset?.ticker}
                   </Typography.Text>
                 </GenericHorizontalItem>
-                <GenericHorizontalItem label="Sender Wallet">
+                <GenericHorizontalItem
+                  label="Source Wallet"
+                  className="whitespace-nowrap"
+                >
                   <Skeleton
                     loading={!sourceAccount}
                     className="min-h-4 max-w-24"
@@ -172,7 +175,10 @@ export const ConfirmTransaction = ({
                     </Copy>
                   </Skeleton>
                 </GenericHorizontalItem>
-                <GenericHorizontalItem label="Source Wallet">
+                <GenericHorizontalItem
+                  label="Destination Wallet"
+                  className="whitespace-nowrap"
+                >
                   <Copy value={destinationAccount?.address ?? ""}>
                     <div className="flex items-center gap-1">
                       <RiFileCopyLine className="w-3 h-3 text-secondary" />

--- a/apps/hestia/src/components/thea/confirmTransaction.tsx
+++ b/apps/hestia/src/components/thea/confirmTransaction.tsx
@@ -52,7 +52,6 @@ export const ConfirmTransaction = ({
     selectedAsset,
     isPolkadexChain,
     polkadexAssets,
-    sourceBalancesLoading,
   } = useTheaProvider();
   const { destinationFee, sourceFee, sourceFeeBalance } = transferConfig ?? {};
 
@@ -90,7 +89,7 @@ export const ConfirmTransaction = ({
     const autoSwapAmount = showAutoSwap ? swapPrice : 0;
     const balance = sourceFeeBalance?.amount ?? 0;
 
-    if (isPolkadexChain) return balance < (sourceFee?.amount ?? 0);
+    if (!isPolkadexChain) return balance < (sourceFee?.amount ?? 0);
 
     return balance < amount + autoSwapAmount;
   }, [
@@ -103,11 +102,6 @@ export const ConfirmTransaction = ({
   ]);
 
   const disabled = useMemo(() => !!error || isLoading, [error, isLoading]);
-
-  const sourceFeeBalanceAmount = useMemo(
-    () => formatAmount(sourceFeeBalance?.amount ?? 0),
-    [sourceFeeBalance?.amount]
-  );
 
   const [
     destinationFeeAmount,
@@ -256,15 +250,6 @@ export const ConfirmTransaction = ({
                     )}
                   </HoverInformation.Content>
                 </HoverInformation>
-
-                <ResponsiveCard
-                  label="Wallet balance"
-                  loading={transferConfigLoading || sourceBalancesLoading}
-                  className="px-3 py-3"
-                >
-                  {sourceFeeBalanceAmount} {sourceFeeTicker}
-                </ResponsiveCard>
-
                 {error && (
                   <ErrorMessage className="p-3">
                     Your balance is not enough to pay the fee.

--- a/apps/hestia/src/components/thea/selectAsset.tsx
+++ b/apps/hestia/src/components/thea/selectAsset.tsx
@@ -29,7 +29,7 @@ export const SelectAsset = ({
   const handleClose = useCallback(() => onOpenChange(false), [onOpenChange]);
   const {
     supportedAssets,
-    setSelectedAsset,
+    onSelectAsset,
     sourceBalances,
     sourceBalancesLoading,
   } = useTheaProvider();
@@ -78,7 +78,7 @@ export const SelectAsset = ({
                           value={e.ticker}
                           className="p-3"
                           onSelect={() => {
-                            setSelectedAsset(e);
+                            onSelectAsset(e);
                             createQueryString({
                               data: [{ name: "asset", value: e.ticker }],
                               pathname,

--- a/apps/hestia/src/components/thea/selectAsset.tsx
+++ b/apps/hestia/src/components/thea/selectAsset.tsx
@@ -13,9 +13,8 @@ import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
 import { useTheaProvider } from "@orderbook/core/providers";
 import { getChainFromTicker } from "@orderbook/core/helpers";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-import { createQueryString, formatAmount } from "@/helpers";
+import { formatAmount } from "@/helpers";
 
 export const SelectAsset = ({
   open,
@@ -33,9 +32,6 @@ export const SelectAsset = ({
     sourceBalances,
     sourceBalancesLoading,
   } = useTheaProvider();
-  const searchParams = useSearchParams();
-  const pathname = usePathname();
-  const { push } = useRouter();
 
   return (
     <Modal
@@ -79,12 +75,6 @@ export const SelectAsset = ({
                           className="p-3"
                           onSelect={() => {
                             onSelectAsset(e);
-                            createQueryString({
-                              data: [{ name: "asset", value: e.ticker }],
-                              pathname,
-                              searchParams,
-                              push,
-                            });
                             onOpenChange(false);
                           }}
                         >

--- a/apps/hestia/src/components/thea/template.tsx
+++ b/apps/hestia/src/components/thea/template.tsx
@@ -60,7 +60,7 @@ export function Template() {
         {mobileView && (browserAccountPresent || extensionAccountPresent) && (
           <div
             ref={interactionRef}
-            className="flex flex-col gap-4 bg-level-1 border-t border-primary py-3 px-2 fixed bottom-0 left-0 w-full"
+            className="flex flex-col gap-4 bg-level-1 border-t border-primary py-2 px-2 fixed bottom-0 left-0 w-full"
           >
             <ResponsiveProfile
               extensionAccountPresent={extensionAccountPresent}

--- a/apps/hestia/src/components/trading/Orders/Balances/columns.tsx
+++ b/apps/hestia/src/components/trading/Orders/Balances/columns.tsx
@@ -92,15 +92,19 @@ export const columns = [
         <ActionsCard
           hideButton
           withdrawLink={{
-            pathname: "https://thea.polkadex.trade/withdraw",
-            query: chainName && {
-              chain: encodeURIComponent(chainName),
+            pathname: "/thea",
+            query: {
+              from: "Polkadex",
+              to: chainName,
+              asset: e.getValue().ticker,
             },
           }}
           depositLink={{
-            pathname: "https://thea.polkadex.trade/",
-            query: chainName && {
-              chain: encodeURIComponent(chainName),
+            pathname: "/thea",
+            query: {
+              from: chainName,
+              to: "Polkadex",
+              asset: e.getValue().ticker,
             },
           }}
           tradeLink={`/trading/${e.getValue().ticker}`}

--- a/apps/hestia/src/components/trading/Orders/Balances/responsiveTable.tsx
+++ b/apps/hestia/src/components/trading/Orders/Balances/responsiveTable.tsx
@@ -41,9 +41,11 @@ export const ResponsiveTable = ({
         <Button.Solid appearance="secondary" asChild>
           <Link
             href={{
-              pathname: "https://thea.polkadex.trade/withdraw",
-              query: chainName && {
-                chain: encodeURIComponent(chainName),
+              pathname: "/thea",
+              query: {
+                from: "Polkadex",
+                to: chainName,
+                asset: ticker,
               },
             }}
           >
@@ -53,9 +55,11 @@ export const ResponsiveTable = ({
         <Button.Solid appearance="secondary" asChild>
           <Link
             href={{
-              pathname: "https://thea.polkadex.trade/",
-              query: chainName && {
-                chain: encodeURIComponent(chainName),
+              pathname: "/thea",
+              query: {
+                from: chainName,
+                to: "Polkadex",
+                asset: ticker,
               },
             }}
           >

--- a/apps/hestia/src/components/trading/PlaceOrder/balance.tsx
+++ b/apps/hestia/src/components/trading/PlaceOrder/balance.tsx
@@ -29,12 +29,13 @@ export const Balance = ({
             <Typography.Text asChild size="sm">
               <Link
                 href={{
-                  pathname: "https://thea.polkadex.trade/withdraw",
-                  query: chainName && {
-                    chain: encodeURIComponent(chainName),
+                  pathname: "/thea",
+                  query: {
+                    from: "Polkadex",
+                    to: chainName,
+                    asset: baseTicker,
                   },
                 }}
-                target="_blank"
               >
                 Withdraw
               </Link>
@@ -44,12 +45,13 @@ export const Balance = ({
             <Typography.Text asChild size="sm">
               <Link
                 href={{
-                  pathname: "https://thea.polkadex.trade/",
-                  query: chainName && {
-                    chain: encodeURIComponent(chainName),
+                  pathname: "/thea",
+                  query: {
+                    from: chainName,
+                    to: "Polkadex",
+                    asset: baseTicker,
                   },
                 }}
-                target="_blank"
               >
                 Deposit
               </Link>

--- a/apps/hestia/src/components/transactions/TheaHistory/filters.tsx
+++ b/apps/hestia/src/components/transactions/TheaHistory/filters.tsx
@@ -98,10 +98,11 @@ export const Filters = <TData,>({
           appearance="secondary"
           size="sm"
           disabled={refetchingLoading}
+          className="gap-1"
         >
           <RiRefreshLine className="w-4 h-4 text-primary" />
           {refetchingLoading && (
-            <Typography.Text appearance="primary" size="xs">
+            <Typography.Text appearance="primary" size="sm">
               Refetching..
             </Typography.Text>
           )}

--- a/apps/hestia/src/components/transactions/TheaHistory/index.tsx
+++ b/apps/hestia/src/components/transactions/TheaHistory/index.tsx
@@ -38,11 +38,7 @@ const actionKeys = ["token", "date"];
 const responsiveKeys = ["hash", "date"];
 
 const polkadexConnector = getChainConnector(GENESIS[0]);
-const assets =
-  polkadexConnector
-    ?.getDestinationChains()
-    .map((c) => polkadexConnector.getSupportedAssets(c))
-    .flat() || [];
+const polkadexAssets = polkadexConnector?.getAllAssets() || [];
 const { getAllChains } = new Thea();
 const chains = getAllChains();
 
@@ -89,7 +85,7 @@ export const TheaHistory = forwardRef<
     },
   ] = useTheaTransactions({
     sourceAddress: mainAddress,
-    assets,
+    assets: polkadexAssets,
     chains,
     baseAssets,
   });
@@ -153,7 +149,7 @@ export const TheaHistory = forwardRef<
             refetchingLoading={depositsRefetching || withdrawalsRefetching}
             data={data}
             chains={chains}
-            assets={assets}
+            assets={polkadexAssets}
             table={table}
             address={mainAddress}
           />

--- a/apps/hestia/src/components/transactions/TheaHistory/index.tsx
+++ b/apps/hestia/src/components/transactions/TheaHistory/index.tsx
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
 "use client";
 
 import { Table, GenericMessage } from "@polkadex/ux";
@@ -41,14 +38,20 @@ const actionKeys = ["token", "date"];
 const responsiveKeys = ["hash", "date"];
 
 const polkadexConnector = getChainConnector(GENESIS[0]);
-const assets = polkadexConnector.getSupportedAssets();
+const assets =
+  polkadexConnector
+    ?.getDestinationChains()
+    .map((c) => polkadexConnector.getSupportedAssets(c))
+    .flat() || [];
 const { getAllChains } = new Thea();
 const chains = getAllChains();
 
 const baseAssets = getAllChains()
   .map((e) =>
     getChainConnector(e.genesis)
-      .getSupportedAssets()
+      .getDestinationChains()
+      .map((c) => getChainConnector(e.genesis).getSupportedAssets(c))
+      .flat()
       .map((x) => (x.id !== undefined ? null : x))
   )
   .flat()

--- a/apps/hestia/src/components/transactions/TheaHistory/index.tsx
+++ b/apps/hestia/src/components/transactions/TheaHistory/index.tsx
@@ -22,7 +22,7 @@ import {
 } from "@tanstack/react-table";
 import classNames from "classnames";
 import { useWindowSize } from "usehooks-ts";
-import { Asset, getChainConnector, Thea } from "@polkadex/thea";
+import { getChainConnector, Thea } from "@polkadex/thea";
 import { GENESIS } from "@orderbook/core/constants";
 import { useProfile } from "@orderbook/core/providers/user/profile";
 
@@ -43,15 +43,9 @@ const { getAllChains } = new Thea();
 const chains = getAllChains();
 
 const baseAssets = getAllChains()
-  .map((e) =>
-    getChainConnector(e.genesis)
-      .getDestinationChains()
-      .map((c) => getChainConnector(e.genesis).getSupportedAssets(c))
-      .flat()
-      .map((x) => (x.id !== undefined ? null : x))
-  )
-  .flat()
-  .filter((e) => e !== null) as NonNullable<Asset[]>;
+  .filter((c) => c.genesis !== GENESIS[0])
+  .map((e) => getChainConnector(e.genesis).getAllAssets())
+  .flat();
 
 export const TheaHistory = forwardRef<
   HTMLDivElement,

--- a/apps/hestia/src/components/transactions/TheaHistory/index.tsx
+++ b/apps/hestia/src/components/transactions/TheaHistory/index.tsx
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
 "use client";
 
 import { Table, GenericMessage } from "@polkadex/ux";

--- a/apps/hestia/src/components/transactions/template.tsx
+++ b/apps/hestia/src/components/transactions/template.tsx
@@ -129,9 +129,7 @@ export function Template() {
                     <Tabs.Trigger value="tradeHistory">
                       Trade History
                     </Tabs.Trigger>
-                    <Tabs.Trigger value="theaHistory">
-                      Thea History
-                    </Tabs.Trigger>
+                    <Tabs.Trigger value="crossChain">Cross Chain</Tabs.Trigger>
                   </Tabs.List>
                   <ScrollArea.Bar orientation="horizontal" />
                 </ScrollArea>
@@ -188,7 +186,7 @@ export function Template() {
                 <ConnectAccountWrapper funding />
               )}
             </Tabs.Content>
-            <Tabs.Content value="theaHistory" className="flex-1 flex">
+            <Tabs.Content value="crossChain" className="flex-1 flex">
               {mainAddress?.length ? (
                 <TheaHistory
                   ref={tableRowsRef}

--- a/apps/hestia/src/components/ui/ConnectWallet/insufficientBalance.tsx
+++ b/apps/hestia/src/components/ui/ConnectWallet/insufficientBalance.tsx
@@ -51,8 +51,8 @@ export const InsufficientBalance = ({
             <GenericInfoCard label="Your balance">
               {balance} PDEX
             </GenericInfoCard>
-            <GenericInfoCard label="Balance required">
-              {">"} {fee} PDEX
+            <GenericInfoCard label="Existential Amount">
+              {fee} PDEX
             </GenericInfoCard>
           </div>
         </div>

--- a/apps/hestia/src/components/ui/ConnectWallet/insufficientBalance.tsx
+++ b/apps/hestia/src/components/ui/ConnectWallet/insufficientBalance.tsx
@@ -98,7 +98,13 @@ export const InsufficientBalance = ({
                             <HoverCard key={asset.id}>
                               <HoverCard.Trigger asChild>
                                 <Link
-                                  href={`https://thea.polkadex.trade/?chain=${encodeURIComponent(chainName)}`}
+                                  href={{
+                                    pathname: "/thea",
+                                    query: {
+                                      from: chainName,
+                                      to: "Polkadex",
+                                    },
+                                  }}
                                   target="_blank"
                                   className={classNames(
                                     !active &&

--- a/apps/hestia/src/components/ui/Footer/QuickStart/index.tsx
+++ b/apps/hestia/src/components/ui/Footer/QuickStart/index.tsx
@@ -89,11 +89,7 @@ export const QuickStart = ({
                 className="underline"
                 asChild
               >
-                <Link
-                  href="https://thea.polkadex.trade/"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
+                <Link href="/thea" target="_blank" rel="noreferrer noopener">
                   using THEA
                 </Link>
               </Typography.Text>

--- a/apps/hestia/src/components/ui/Header/fundWalletModal.tsx
+++ b/apps/hestia/src/components/ui/Header/fundWalletModal.tsx
@@ -77,7 +77,7 @@ export const FundWalletModal = ({
                           <Dropdown.Item
                             key={asset.id}
                             onClick={() =>
-                              window.open(`/thea?from=${chainName}`)
+                              window.open(`/thea?from=${chainName}`, "_self")
                             }
                           >
                             <div className="flex items-center justify-center gap-2">
@@ -115,7 +115,7 @@ export const FundWalletModal = ({
                           <Dropdown.Item
                             key={asset.id}
                             onClick={() =>
-                              window.open(`/thea?from=${chainName}`)
+                              window.open(`/thea?from=${chainName}`, "_self")
                             }
                           >
                             <div className="flex items-center justify-center gap-2">
@@ -156,6 +156,7 @@ export const FundWalletModal = ({
               title="Transfer to trading account"
               description="Move funds from your funding account to your trading account."
               href="/transfer/USDT?type=deposit"
+              onClick={() => onOpenChange(false)}
             />
           </div>
         </div>

--- a/apps/hestia/src/components/ui/Header/fundWalletModal.tsx
+++ b/apps/hestia/src/components/ui/Header/fundWalletModal.tsx
@@ -77,9 +77,7 @@ export const FundWalletModal = ({
                           <Dropdown.Item
                             key={asset.id}
                             onClick={() =>
-                              window.open(
-                                `https://thea.polkadex.trade/?chain=${encodeURIComponent(chainName)}`
-                              )
+                              window.open(`/thea?from=${chainName}`)
                             }
                           >
                             <div className="flex items-center justify-center gap-2">
@@ -117,9 +115,7 @@ export const FundWalletModal = ({
                           <Dropdown.Item
                             key={asset.id}
                             onClick={() =>
-                              window.open(
-                                `https://thea.polkadex.trade/?chain=${encodeURIComponent(chainName)}`
-                              )
+                              window.open(`/thea?from=${chainName}`)
                             }
                           >
                             <div className="flex items-center justify-center gap-2">

--- a/apps/hestia/src/components/ui/Header/index.tsx
+++ b/apps/hestia/src/components/ui/Header/index.tsx
@@ -99,6 +99,10 @@ export const Header = forwardRef<HTMLDivElement>((_, ref) => {
             <HeaderLink.Dropdown
               items={[
                 {
+                  href: "https://pdexanalytics.com",
+                  label: "Analytics",
+                },
+                {
                   href: "https://github.com/Polkadex-Substrate/Docs/blob/master/Polkadex_Terms_of_Use.pdf",
                   label: "Terms of use",
                 },
@@ -117,10 +121,6 @@ export const Header = forwardRef<HTMLDivElement>((_, ref) => {
                 {
                   href: "https://github.com/Polkadex-Substrate/Docs/blob/master/Polkadex_Data_Retention_Policy.pdf",
                   label: "Data Retention Policy",
-                },
-                {
-                  href: "https://pdexanalytics.com",
-                  label: "Analytics",
                 },
               ]}
             >

--- a/apps/hestia/src/helpers/formatAmount.ts
+++ b/apps/hestia/src/helpers/formatAmount.ts
@@ -2,6 +2,9 @@ import { parseScientific } from "@orderbook/core/helpers";
 import { trimFloat } from "@polkadex/numericals";
 // NAN with 2,804
 export const formatAmount = (amount: number) => {
-  const trimmedBalance = trimFloat({ value: amount });
-  return parseScientific(trimmedBalance.toString());
+  const trimmedBalance = trimFloat({
+    value: parseScientific(amount.toString()),
+  });
+  console.log(trimmedBalance);
+  return trimmedBalance;
 };

--- a/apps/hestia/src/helpers/formatAmount.ts
+++ b/apps/hestia/src/helpers/formatAmount.ts
@@ -5,6 +5,5 @@ export const formatAmount = (amount: number) => {
   const trimmedBalance = trimFloat({
     value: parseScientific(amount.toString()),
   });
-  console.log(trimmedBalance);
   return trimmedBalance;
 };

--- a/apps/hestia/src/hooks/useBridge.ts
+++ b/apps/hestia/src/hooks/useBridge.ts
@@ -9,9 +9,9 @@ import { useNativeApi } from "@orderbook/core/providers/public/nativeApi";
 import { signAndSubmitPromiseWrapper } from "@polkadex/blockchain-api";
 
 const withdrawMessage =
-  "After withdrawal initiation, expect tokens on the destination chain in 2-3 minutes";
+  "After withdrawal initiation, expect tokens on the destination chain in a few minutes";
 const depositMessage =
-  "Deposit Success. Processed transactions take up to 20 minutes to appear on the History";
+  "Deposit Success. Processed transactions take a few minutes to appear in History";
 
 export function useBridge({ onSuccess }: { onSuccess: () => void }) {
   const { api } = useNativeApi();
@@ -28,6 +28,12 @@ export function useBridge({ onSuccess }: { onSuccess: () => void }) {
       if (!transferConfig || !sourceAccount || !api) {
         onHandleError?.("Bridge issue");
         return;
+      }
+
+      if (
+        transferConfig.sourceFee.amount > transferConfig.sourceFeeBalance.amount
+      ) {
+        throw new Error("Insufficient transaction fee balance on source chain");
       }
 
       const ext = await transferConfig.transfer<SubmittableExtrinsic>(amount);

--- a/apps/hestia/src/hooks/useBridge.ts
+++ b/apps/hestia/src/hooks/useBridge.ts
@@ -47,9 +47,7 @@ export function useBridge({ onSuccess }: { onSuccess: () => void }) {
       ) {
         const usdtAsset =
           destinationConnector
-            ?.getDestinationChains()
-            .map((c) => destinationConnector.getSupportedAssets(c))
-            .flat()
+            ?.getAllAssets()
             .filter((a) => a.ticker === "USDT") || [];
 
         const usdtBalance =

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@polkadex/thea": "^5.0.0",
+    "@polkadex/thea": "^5.2.0",
     "@polkadex/react-providers": "^2.2.0",
     "@polkadot-cloud/assets": "^0.3.0",
     "@polkadot/api": "^10.12.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@polkadex/thea": "^5.2.0",
+    "@polkadex/thea": "^5.3.0",
     "@polkadex/react-providers": "^2.2.0",
     "@polkadot-cloud/assets": "^0.3.0",
     "@polkadot/api": "^10.12.6",

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -74,6 +74,7 @@ export const ErrorMessages = (existential = "0", minAmount = "0") => ({
   MUST_BE_A_NUMBER: "Must be a number",
   TOO_SMALL: "Too Small!",
   MIN: `The amount must be greater than ${minAmount}`,
+  EXISTENTIAL_DEPOSIT: `You need to keep some amount in source chain to cover the existential deposit`,
 });
 
 export const MAX_DIGITS_AFTER_DECIMAL = 8;

--- a/packages/core/src/constants/queryKeys.ts
+++ b/packages/core/src/constants/queryKeys.ts
@@ -120,11 +120,12 @@ export const QUERY_KEYS = {
     assetsAmount,
   ],
   queryPools: () => [PREFIX, "queryPools"],
-  getTheaBalances: (address: string, chain: string) => [
+  getTheaBalances: (address: string, chain: string, assets: string[]) => [
     PREFIX,
     "getTheaBalances",
     address,
     chain,
+    assets,
   ],
   getTheDeposits: (address: string, assets: number) => [
     PREFIX,

--- a/packages/core/src/helpers/getChainFromTicker.ts
+++ b/packages/core/src/helpers/getChainFromTicker.ts
@@ -2,31 +2,28 @@
 export const getChainFromTicker = (ticker: string): string => {
   // Should update it whenever any new asset is added to orderbook
   switch (ticker) {
+    case "USDC":
+    case "PINK":
+    case "DED":
     case "USDT":
-      return "Asset Hub";
+      return "AssetHub";
     case "ASTR":
-      return "Astar Network";
+      return "Astar";
     case "DOT":
       return "Polkadot";
     case "IBTC":
       return "Interlay";
     case "PHA":
-      return "Phala Network";
+      return "Phala";
     case "GLMR":
-      return "Moonbeam Network";
+      return "Moonbeam";
     case "PDEX":
       return "Polkadex";
-    case "DED":
-      return "Asset Hub";
     case "UNQ":
-      return "Unique Network";
-    case "USDC":
-      return "Asset Hub";
-    case "PINK":
-      return "Asset Hub";
+      return "Unique";
     case "vDOT":
     case "BNC":
-      return "Bifrost Network";
+      return "Bifrost";
     default:
       return "Unknown";
   }

--- a/packages/core/src/hooks/useTheaBalances.tsx
+++ b/packages/core/src/hooks/useTheaBalances.tsx
@@ -21,7 +21,11 @@ export const useTheaBalances = ({
   );
 
   return useQuery({
-    queryKey: QUERY_KEYS.getTheaBalances(sourceAddress, chain),
+    queryKey: QUERY_KEYS.getTheaBalances(
+      sourceAddress,
+      chain,
+      assets.map((a) => a.ticker)
+    ),
     enabled,
     queryFn: async () => await connector?.getBalances(sourceAddress, assets),
   });

--- a/packages/core/src/hooks/useTheaBalances.tsx
+++ b/packages/core/src/hooks/useTheaBalances.tsx
@@ -28,5 +28,6 @@ export const useTheaBalances = ({
     ),
     enabled,
     queryFn: async () => await connector?.getBalances(sourceAddress, assets),
+    refetchInterval: 12 * 1000,
   });
 };

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -155,6 +155,22 @@ export const TheaProvider = ({
     [polkadexConnector]
   );
 
+  const { data: polkadexDestinationBalances = [] } = useTheaBalances({
+    connector: polkadexConnector,
+    sourceAddress: destinationAccountSelected?.address,
+    assets: polkadexAssets,
+    chain: GENESIS[0],
+  });
+
+  const destinationPDEXBalance = useMemo(
+    () =>
+      polkadexDestinationBalances
+        ? polkadexDestinationBalances.find((e) => e.ticker === "PDEX")
+            ?.amount ?? 0 // Remove static data
+        : 0,
+    [polkadexDestinationBalances]
+  );
+
   /* Default Selection Logic  */
   const initialSource = useMemo(() => {
     if (chains) {
@@ -202,6 +218,7 @@ export const TheaProvider = ({
     supportedAssets,
   ]);
 
+  /* Fetch balance for supported assets for source chain */
   const {
     data: sourceBalances = [],
     isLoading: sourceBalancesLoading,
@@ -215,22 +232,7 @@ export const TheaProvider = ({
     chain: sourceChain?.genesis,
   });
 
-  const { data: polkadexDestinationBalances = [] } = useTheaBalances({
-    connector: polkadexConnector,
-    sourceAddress: destinationAccountSelected?.address,
-    assets: polkadexAssets,
-    chain: GENESIS[0],
-  });
-
-  const destinationPDEXBalance = useMemo(
-    () =>
-      polkadexDestinationBalances
-        ? polkadexDestinationBalances.find((e) => e.ticker === "PDEX")
-            ?.amount ?? 0 // Remove static data
-        : 0,
-    [polkadexDestinationBalances]
-  );
-
+  /* Fetch transfer config for selected asset & source chain */
   const {
     data: transferConfig,
     isLoading: transferConfigLoading,
@@ -261,6 +263,7 @@ export const TheaProvider = ({
   return (
     <Provider
       value={{
+        supportedSourceChains: chains,
         sourceConnector,
 
         sourceAccount: sourceAccountSelected,
@@ -272,13 +275,10 @@ export const TheaProvider = ({
         onSelectSourceChain,
         destinationChain,
         onSelectDestinationChain,
-        supportedSourceChains: chains,
         supportedDestinationChains,
         onSwitchChain,
 
         supportedAssets,
-        polkadexAssets,
-
         selectedAsset,
         onSelectAsset,
         selectedAssetBalance,
@@ -295,6 +295,7 @@ export const TheaProvider = ({
 
         destinationPDEXBalance,
         isPolkadexChain,
+        polkadexAssets,
       }}
     >
       {children}

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -91,6 +91,18 @@ export const TheaProvider = ({
     [destinationAccount, selectedWallet]
   );
 
+  const onSelectDestinationChain = (chain: Chain) => {
+    if (
+      !sourceConnector
+        ?.getDestinationChains()
+        .some((e) => e.genesis === chain.genesis)
+    )
+      return;
+    const selectedAsset = sourceConnector.getSupportedAssets(chain)[0];
+    setDestinationChain(chain);
+    setSelectedAsset(selectedAsset);
+  };
+
   /* Asset */
   const supportedAssets = useMemo(
     () =>
@@ -188,31 +200,6 @@ export const TheaProvider = ({
     chain: GENESIS[0],
   });
 
-  const selectedAssetSupported = useMemo(
-    () =>
-      !!selectedAsset &&
-      supportedAssets?.find((e) => e.ticker.includes(selectedAsset.ticker)),
-    [selectedAsset, supportedAssets]
-  );
-
-  useEffect(() => {
-    if (
-      selectedAsset &&
-      sourceChain &&
-      destinationChain &&
-      supportedAssets &&
-      !selectedAssetSupported
-    ) {
-      setSelectedAsset(null);
-    }
-  }, [
-    destinationChain,
-    selectedAsset,
-    selectedAssetSupported,
-    sourceChain,
-    supportedAssets,
-  ]);
-
   const destinationPDEXBalance = useMemo(
     () =>
       polkadexDestinationBalances
@@ -262,7 +249,7 @@ export const TheaProvider = ({
         sourceChain,
         onSelectSourceChain,
         destinationChain,
-        setDestinationChain,
+        onSelectDestinationChain,
         supportedSourceChains: chains,
         supportedDestinationChains,
 
@@ -304,7 +291,7 @@ type State = {
   setDestinationAccount: Dispatch<SetStateAction<ExtensionAccount | undefined>>;
 
   destinationChain: Chain | null;
-  setDestinationChain: Dispatch<SetStateAction<Chain | null>>;
+  onSelectDestinationChain: (chain: Chain) => void;
   sourceChain: Chain | null;
   onSelectSourceChain: (chain: Chain) => void;
 
@@ -337,7 +324,7 @@ export const Context = createContext<State>({
   setDestinationAccount: () => {},
 
   destinationChain: null,
-  setDestinationChain: () => {},
+  onSelectDestinationChain: () => {},
   sourceChain: null,
   onSelectSourceChain: () => {},
   supportedSourceChains: [],

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -23,7 +23,7 @@ import { defaultConfig } from "@orderbook/core/config";
 import { ExtensionAccount } from "@polkadex/react-providers";
 import { useTheaBalances, useTheaConfig } from "@orderbook/core/hooks";
 import { isIdentical } from "@orderbook/core/helpers";
-import { GENESIS, POLKADEX_ASSET } from "@orderbook/core/constants";
+import { GENESIS } from "@orderbook/core/constants";
 import { UseQueryResult } from "@tanstack/react-query";
 
 import { useConnectWalletProvider } from "../connectWalletProvider";
@@ -146,17 +146,7 @@ export const TheaProvider = ({
   );
 
   const polkadexAssets = useMemo(
-    () => [
-      {
-        ticker: POLKADEX_ASSET.ticker,
-        logo: POLKADEX_ASSET.ticker,
-        decimal: POLKADEX_ASSET.decimal,
-      },
-      ...(polkadexConnector
-        ?.getDestinationChains()
-        .map((c) => polkadexConnector.getSupportedAssets(c))
-        .flat() || []),
-    ],
+    () => polkadexConnector?.getAllAssets() || [],
     [polkadexConnector]
   );
 

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -187,12 +187,17 @@ export const TheaProvider = ({
 
   const initialDestination = useMemo(() => {
     if (chains) {
+      const defaultChain =
+        initialSourceName !== defaultTheaDestinationChain
+          ? isIdentical(chains, defaultTheaDestinationChain, "name")
+          : undefined;
+
       return !!initialDestinationName &&
         initialSourceName !== initialDestinationName
         ? isIdentical(chains, initialDestinationName, "name")
-        : isIdentical(chains, defaultTheaDestinationChain, "name");
+        : defaultChain;
     }
-  }, [initialDestinationName, initialSourceName, chains]);
+  }, [chains, initialDestinationName, initialSourceName]);
 
   const initialAsset = useMemo(() => {
     if (supportedAssets) {
@@ -204,13 +209,18 @@ export const TheaProvider = ({
   }, [initialAssetTicker, supportedAssets]);
 
   useEffect(() => {
-    if (initialDestination && !destinationChain)
-      setDestinationChain(initialDestination);
-  }, [initialDestination, destinationChain]);
-
-  useEffect(() => {
     if (initialSource && !sourceChain) setSourceChain(initialSource);
   }, [initialSource, sourceChain]);
+
+  useEffect(() => {
+    if (!destinationChain && sourceChain && supportedDestinationChains)
+      setDestinationChain(initialDestination || supportedDestinationChains[0]);
+  }, [
+    initialDestination,
+    destinationChain,
+    supportedDestinationChains,
+    sourceChain,
+  ]);
 
   useEffect(() => {
     if (!selectedAsset && destinationChain && sourceChain && supportedAssets)

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -86,11 +86,6 @@ export const TheaProvider = ({
   };
 
   /* Destination */
-  const destinationConnector = useMemo(
-    () => destinationChain && getChainConnector(destinationChain.genesis),
-    [destinationChain]
-  );
-
   const destinationAccountSelected = useMemo(
     () => destinationAccount ?? selectedWallet,
     [destinationAccount, selectedWallet]
@@ -106,17 +101,26 @@ export const TheaProvider = ({
   );
 
   const onSelectAsset = (asset: Asset) => {
+    if (!supportedAssets.some((e) => e.ticker === asset.ticker)) return;
     setSelectedAsset(asset);
   };
 
   /* Polkadex */
+  const isPolkadexChain = useMemo(
+    () => !!(sourceChain?.genesis === GENESIS[0]),
+    [sourceChain?.genesis]
+  );
+
   const polkadexConnector = useMemo(
     () => destinationChain && getChainConnector(GENESIS[0]),
     [destinationChain]
   );
 
   // TODO: Fix it
-  const polkadexAssets = useMemo(() => [], []);
+  const polkadexAssets = useMemo(
+    () => (isPolkadexChain ? supportedAssets : []),
+    [isPolkadexChain, supportedAssets]
+  );
 
   const initialAsset = useMemo(() => {
     if (supportedAssets) {
@@ -209,11 +213,6 @@ export const TheaProvider = ({
     supportedAssets,
   ]);
 
-  const isPolkadexChain = useMemo(
-    () => !!(sourceChain?.genesis === GENESIS[0]),
-    [sourceChain?.genesis]
-  );
-
   const destinationPDEXBalance = useMemo(
     () =>
       polkadexDestinationBalances
@@ -254,7 +253,6 @@ export const TheaProvider = ({
     <Provider
       value={{
         sourceConnector,
-        destinationConnector,
 
         sourceAccount: sourceAccountSelected,
         setSourceAccount,
@@ -296,7 +294,6 @@ export const TheaProvider = ({
 
 type State = {
   sourceConnector: BaseChainAdapter | null;
-  destinationConnector: BaseChainAdapter | null;
 
   sourceAccount?: ExtensionAccount;
   setSourceAccount: Dispatch<SetStateAction<ExtensionAccount | undefined>>;
@@ -333,7 +330,6 @@ type State = {
 };
 export const Context = createContext<State>({
   sourceConnector: null,
-  destinationConnector: null,
 
   sourceAccount: undefined,
   setSourceAccount: () => {},

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -67,37 +67,22 @@ export const TheaProvider = ({
     [sourceChain]
   );
 
-  const supportedAssets = useMemo(
-    () => sourceConnector?.getSupportedAssets() || [],
-    [sourceConnector]
-  );
-
   const sourceAccountSelected = useMemo(
     () => sourceAccount ?? selectedWallet,
     [sourceAccount, selectedWallet]
   );
 
   const supportedDestinationChains = useMemo(() => {
-    return (
-      (selectedAsset && sourceConnector?.getDestinationChains(selectedAsset)) ||
-      []
-    );
-  }, [selectedAsset, sourceConnector]);
+    return sourceConnector?.getDestinationChains() || [];
+  }, [sourceConnector]);
 
   const onSelectSourceChain = (chain: Chain) => {
     const connector = getChainConnector(chain.genesis);
-    // Select the first asset which some available destination chains
-    for (const asset of connector.getSupportedAssets()) {
-      if (connector.getDestinationChains(asset).length > 0) {
-        const selectedAsset = asset;
-        const selectedDestinationChain =
-          connector.getDestinationChains(asset)[0];
-        setSourceChain(chain);
-        setSelectedAsset(selectedAsset);
-        setDestinationChain(selectedDestinationChain);
-        break;
-      }
-    }
+    const destChain = connector.getDestinationChains()[0];
+    const selectedAsset = connector.getSupportedAssets(destChain)[0];
+    setSourceChain(chain);
+    setDestinationChain(destChain);
+    setSelectedAsset(selectedAsset);
   };
 
   /* Destination */
@@ -111,17 +96,16 @@ export const TheaProvider = ({
     [destinationAccount, selectedWallet]
   );
 
-  const destinationAssets = useMemo(
-    () => destinationConnector?.getSupportedAssets() || [],
-    [destinationConnector]
+  /* Asset */
+  const supportedAssets = useMemo(
+    () =>
+      (destinationChain &&
+        sourceConnector?.getSupportedAssets(destinationChain)) ||
+      [],
+    [destinationChain, sourceConnector]
   );
 
-  /* Asset */
   const onSelectAsset = (asset: Asset) => {
-    if (!sourceConnector) return;
-    const selectedDestinationChain =
-      sourceConnector.getDestinationChains(asset)[0];
-    setDestinationChain(selectedDestinationChain);
     setSelectedAsset(asset);
   };
 
@@ -131,10 +115,8 @@ export const TheaProvider = ({
     [destinationChain]
   );
 
-  const polkadexAssets = useMemo(
-    () => polkadexConnector?.getSupportedAssets() || [],
-    [polkadexConnector]
-  );
+  // TODO: Fix it
+  const polkadexAssets = useMemo(() => [], []);
 
   const initialAsset = useMemo(() => {
     if (supportedAssets) {
@@ -287,7 +269,6 @@ export const TheaProvider = ({
         supportedDestinationChains,
 
         supportedAssets,
-        destinationAssets,
         polkadexAssets,
 
         selectedAsset,
@@ -331,7 +312,6 @@ type State = {
   onSelectSourceChain: (chain: Chain) => void;
 
   supportedAssets: Asset[];
-  destinationAssets: Asset[];
   polkadexAssets: Asset[];
 
   selectedAsset: Asset | null;
@@ -368,7 +348,6 @@ export const Context = createContext<State>({
   supportedDestinationChains: [],
 
   supportedAssets: [],
-  destinationAssets: [],
   polkadexAssets: [],
 
   selectedAsset: null,

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -117,6 +117,18 @@ export const TheaProvider = ({
     setSelectedAsset(asset);
   };
 
+  /* Switch Chain */
+  const onSwitchChain = () => {
+    if (!destinationChain || !sourceChain) return;
+    const source = destinationChain;
+    const destination = sourceChain;
+    setSourceChain(source);
+    setDestinationChain(destination);
+    const connector = getChainConnector(source.genesis);
+    const selectedAsset = connector.getSupportedAssets(destination)[0];
+    setSelectedAsset(selectedAsset);
+  };
+
   /* Polkadex */
   const isPolkadexChain = useMemo(
     () => !!(sourceChain?.genesis === GENESIS[0]),
@@ -253,6 +265,7 @@ export const TheaProvider = ({
         onSelectDestinationChain,
         supportedSourceChains: chains,
         supportedDestinationChains,
+        onSwitchChain,
 
         supportedAssets,
         polkadexAssets,
@@ -295,6 +308,7 @@ type State = {
   onSelectDestinationChain: (chain: Chain) => void;
   sourceChain: Chain | null;
   onSelectSourceChain: (chain: Chain) => void;
+  onSwitchChain: () => void;
 
   supportedAssets: Asset[];
   polkadexAssets: Asset[];
@@ -330,6 +344,7 @@ export const Context = createContext<State>({
   onSelectSourceChain: () => {},
   supportedSourceChains: [],
   supportedDestinationChains: [],
+  onSwitchChain: () => {},
 
   supportedAssets: [],
   polkadexAssets: [],

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -81,6 +81,13 @@ export const TheaProvider = ({
     [destinationChain]
   );
 
+  const supportedDestinationChains = useMemo(() => {
+    return (
+      (selectedAsset && sourceConnector?.getDestinationChains(selectedAsset)) ||
+      []
+    );
+  }, [selectedAsset, sourceConnector]);
+
   const polkadexConnector = useMemo(
     () => destinationChain && getChainConnector(GENESIS[0]),
     [destinationChain]
@@ -259,7 +266,8 @@ export const TheaProvider = ({
         setSourceChain,
         destinationChain,
         setDestinationChain,
-        chains,
+        supportedSourceChains: chains,
+        supportedDestinationChains,
 
         supportedAssets,
         destinationAssets,
@@ -295,7 +303,8 @@ type State = {
 
   sourceAccount?: ExtensionAccount;
   setSourceAccount: Dispatch<SetStateAction<ExtensionAccount | undefined>>;
-  chains: Chain[];
+  supportedSourceChains: Chain[];
+  supportedDestinationChains: Chain[];
 
   destinationAccount?: ExtensionAccount;
   setDestinationAccount: Dispatch<SetStateAction<ExtensionAccount | undefined>>;
@@ -340,7 +349,8 @@ export const Context = createContext<State>({
   setDestinationChain: () => {},
   sourceChain: null,
   setSourceChain: () => {},
-  chains: [],
+  supportedSourceChains: [],
+  supportedDestinationChains: [],
 
   supportedAssets: [],
   destinationAssets: [],

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -84,7 +84,7 @@ export const TheaProvider = ({
     );
   }, [selectedAsset, sourceConnector]);
 
-  const onChangeSourceChain = (chain: Chain) => {
+  const onSelectSourceChain = (chain: Chain) => {
     const connector = getChainConnector(chain.genesis);
     // Select the first asset which some available destination chains
     for (const asset of connector.getSupportedAssets()) {
@@ -271,7 +271,7 @@ export const TheaProvider = ({
         setDestinationAccount,
 
         sourceChain,
-        onChangeSourceChain,
+        onSelectSourceChain,
         destinationChain,
         setDestinationChain,
         supportedSourceChains: chains,
@@ -319,7 +319,7 @@ type State = {
   destinationChain: Chain | null;
   setDestinationChain: Dispatch<SetStateAction<Chain | null>>;
   sourceChain: Chain | null;
-  onChangeSourceChain: (chain: Chain) => void;
+  onSelectSourceChain: (chain: Chain) => void;
 
   supportedAssets: Asset[];
   destinationAssets: Asset[];
@@ -354,7 +354,7 @@ export const Context = createContext<State>({
   destinationChain: null,
   setDestinationChain: () => {},
   sourceChain: null,
-  onChangeSourceChain: () => {},
+  onSelectSourceChain: () => {},
   supportedSourceChains: [],
   supportedDestinationChains: [],
 

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -55,30 +55,26 @@ export const TheaProvider = ({
 
   const { getAllChains } = useMemo(() => new Thea(), []);
 
-  const sourceAccountSelected = useMemo(
-    () => sourceAccount ?? selectedWallet,
-    [sourceAccount, selectedWallet]
-  );
-
-  const destinationAccountSelected = useMemo(
-    () => destinationAccount ?? selectedWallet,
-    [destinationAccount, selectedWallet]
-  );
-
   const chains = useMemo(
     () =>
       getAllChains()?.filter((e) => !disabledTheaChains.includes(e.genesis)),
     [getAllChains]
   );
 
+  /** Source  **/
   const sourceConnector = useMemo(
     () => sourceChain && getChainConnector(sourceChain.genesis),
     [sourceChain]
   );
 
-  const destinationConnector = useMemo(
-    () => destinationChain && getChainConnector(destinationChain.genesis),
-    [destinationChain]
+  const sourceAssets = useMemo(
+    () => sourceConnector?.getSupportedAssets() || [],
+    [sourceConnector]
+  );
+
+  const sourceAccountSelected = useMemo(
+    () => sourceAccount ?? selectedWallet,
+    [sourceAccount, selectedWallet]
   );
 
   const supportedDestinationChains = useMemo(() => {
@@ -88,24 +84,19 @@ export const TheaProvider = ({
     );
   }, [selectedAsset, sourceConnector]);
 
-  const polkadexConnector = useMemo(
-    () => destinationChain && getChainConnector(GENESIS[0]),
+  /* Destination */
+  const destinationConnector = useMemo(
+    () => destinationChain && getChainConnector(destinationChain.genesis),
     [destinationChain]
   );
 
-  const sourceAssets = useMemo(
-    () => (sourceConnector ? sourceConnector.getSupportedAssets() : []),
-    [sourceConnector]
-  );
-
-  const polkadexAssets = useMemo(
-    () => (polkadexConnector ? polkadexConnector.getSupportedAssets() : []),
-    [polkadexConnector]
+  const destinationAccountSelected = useMemo(
+    () => destinationAccount ?? selectedWallet,
+    [destinationAccount, selectedWallet]
   );
 
   const destinationAssets = useMemo(
-    () =>
-      destinationConnector ? destinationConnector.getSupportedAssets() : [],
+    () => destinationConnector?.getSupportedAssets() || [],
     [destinationConnector]
   );
 
@@ -117,6 +108,17 @@ export const TheaProvider = ({
           )
         : [],
     [sourceAssets, destinationAssets]
+  );
+
+  /* Polkadex */
+  const polkadexConnector = useMemo(
+    () => destinationChain && getChainConnector(GENESIS[0]),
+    [destinationChain]
+  );
+
+  const polkadexAssets = useMemo(
+    () => polkadexConnector?.getSupportedAssets() || [],
+    [polkadexConnector]
   );
 
   const initialAsset = useMemo(() => {

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -134,15 +134,7 @@ export const TheaProvider = ({
     [isPolkadexChain, supportedAssets]
   );
 
-  const initialAsset = useMemo(() => {
-    if (supportedAssets) {
-      const asset =
-        initialAssetTicker &&
-        isIdentical(supportedAssets, initialAssetTicker, "ticker");
-      return asset || supportedAssets[0];
-    }
-  }, [initialAssetTicker, supportedAssets]);
-
+  /* Default Selection Logic  */
   const initialSource = useMemo(() => {
     if (chains) {
       return !!initialSourceName && initialSourceName !== initialDestinationName
@@ -159,6 +151,15 @@ export const TheaProvider = ({
         : isIdentical(chains, defaultTheaDestinationChain, "name");
     }
   }, [initialDestinationName, initialSourceName, chains]);
+
+  const initialAsset = useMemo(() => {
+    if (supportedAssets) {
+      const asset =
+        initialAssetTicker &&
+        isIdentical(supportedAssets, initialAssetTicker, "ticker");
+      return asset || supportedAssets[0];
+    }
+  }, [initialAssetTicker, supportedAssets]);
 
   useEffect(() => {
     if (initialDestination && !destinationChain)

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -116,6 +116,15 @@ export const TheaProvider = ({
     [destinationConnector]
   );
 
+  /* Asset */
+  const onSelectAsset = (asset: Asset) => {
+    if (!sourceConnector) return;
+    const selectedDestinationChain =
+      sourceConnector.getDestinationChains(asset)[0];
+    setDestinationChain(selectedDestinationChain);
+    setSelectedAsset(asset);
+  };
+
   /* Polkadex */
   const polkadexConnector = useMemo(
     () => destinationChain && getChainConnector(GENESIS[0]),
@@ -282,7 +291,7 @@ export const TheaProvider = ({
         polkadexAssets,
 
         selectedAsset,
-        setSelectedAsset,
+        onSelectAsset,
         selectedAssetBalance,
 
         sourceBalances,
@@ -326,7 +335,7 @@ type State = {
   polkadexAssets: Asset[];
 
   selectedAsset: Asset | null;
-  setSelectedAsset: Dispatch<SetStateAction<Asset | null>>;
+  onSelectAsset: (asset: Asset) => void;
   selectedAssetBalance: number;
 
   sourceBalances: AssetAmount[];
@@ -363,7 +372,7 @@ export const Context = createContext<State>({
   polkadexAssets: [],
 
   selectedAsset: null,
-  setSelectedAsset: () => {},
+  onSelectAsset: () => {},
   selectedAssetBalance: 0,
 
   sourceBalances: [],

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -61,7 +61,7 @@ export const TheaProvider = ({
     [getAllChains]
   );
 
-  /** Source  **/
+  /** Source Chain  **/
   const sourceConnector = useMemo(
     () => sourceChain && getChainConnector(sourceChain.genesis),
     [sourceChain]
@@ -85,7 +85,7 @@ export const TheaProvider = ({
     setSelectedAsset(selectedAsset);
   };
 
-  /* Destination */
+  /* Destination Chain */
   const destinationAccountSelected = useMemo(
     () => destinationAccount ?? selectedWallet,
     [destinationAccount, selectedWallet]
@@ -125,8 +125,8 @@ export const TheaProvider = ({
     setSourceChain(source);
     setDestinationChain(destination);
     const connector = getChainConnector(source.genesis);
-    const selectedAsset = connector.getSupportedAssets(destination)[0];
-    setSelectedAsset(selectedAsset);
+    const asset = selectedAsset ?? connector.getSupportedAssets(destination)[0];
+    setSelectedAsset(asset);
   };
 
   /* Polkadex */

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -23,7 +23,7 @@ import { defaultConfig } from "@orderbook/core/config";
 import { ExtensionAccount } from "@polkadex/react-providers";
 import { useTheaBalances, useTheaConfig } from "@orderbook/core/hooks";
 import { isIdentical } from "@orderbook/core/helpers";
-import { GENESIS } from "@orderbook/core/constants";
+import { GENESIS, POLKADEX_ASSET } from "@orderbook/core/constants";
 import { UseQueryResult } from "@tanstack/react-query";
 
 import { useConnectWalletProvider } from "../connectWalletProvider";
@@ -140,10 +140,19 @@ export const TheaProvider = ({
     [destinationChain]
   );
 
-  // TODO: Fix it
   const polkadexAssets = useMemo(
-    () => (isPolkadexChain ? supportedAssets : []),
-    [isPolkadexChain, supportedAssets]
+    () => [
+      {
+        ticker: POLKADEX_ASSET.ticker,
+        logo: POLKADEX_ASSET.ticker,
+        decimal: POLKADEX_ASSET.decimal,
+      },
+      ...(polkadexConnector
+        ?.getDestinationChains()
+        .map((c) => polkadexConnector.getSupportedAssets(c))
+        .flat() || []),
+    ],
+    [polkadexConnector]
   );
 
   /* Default Selection Logic  */

--- a/packages/core/src/providers/user/thea/index.tsx
+++ b/packages/core/src/providers/user/thea/index.tsx
@@ -86,6 +86,11 @@ export const TheaProvider = ({
   };
 
   /* Destination Chain */
+  const destinationConnector = useMemo(
+    () => destinationChain && getChainConnector(destinationChain.genesis),
+    [destinationChain]
+  );
+
   const destinationAccountSelected = useMemo(
     () => destinationAccount ?? selectedWallet,
     [destinationAccount, selectedWallet]
@@ -265,6 +270,7 @@ export const TheaProvider = ({
       value={{
         supportedSourceChains: chains,
         sourceConnector,
+        destinationConnector,
 
         sourceAccount: sourceAccountSelected,
         setSourceAccount,
@@ -305,6 +311,7 @@ export const TheaProvider = ({
 
 type State = {
   sourceConnector: BaseChainAdapter | null;
+  destinationConnector: BaseChainAdapter | null;
 
   sourceAccount?: ExtensionAccount;
   setSourceAccount: Dispatch<SetStateAction<ExtensionAccount | undefined>>;
@@ -342,6 +349,7 @@ type State = {
 };
 export const Context = createContext<State>({
   sourceConnector: null,
+  destinationConnector: null,
 
   sourceAccount: undefined,
   setSourceAccount: () => {},

--- a/packages/core/src/validations/index.ts
+++ b/packages/core/src/validations/index.ts
@@ -10,7 +10,11 @@ import {
   MAX_DIGITS_AFTER_DECIMAL,
 } from "@orderbook/core/constants";
 
-export const bridgeValidations = (minAmount = 0, balance = 0) => {
+export const bridgeValidations = (
+  minAmount = 0,
+  maxAmount = 0,
+  balance = 0
+) => {
   const min = formatAmount(minAmount);
 
   return Yup.object().shape({
@@ -35,6 +39,11 @@ export const bridgeValidations = (minAmount = 0, balance = 0) => {
         ErrorMessages().CHECK_BALANCE,
         ErrorMessages().CHECK_BALANCE,
         (value) => Number(value) <= Number(balance)
+      )
+      .test(
+        ErrorMessages().EXISTENTIAL_DEPOSIT,
+        ErrorMessages().EXISTENTIAL_DEPOSIT,
+        (value) => Number(value) <= Number(maxAmount)
       )
       .test(
         ErrorMessages().CHECK_VALID_AMOUNT,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3867,10 +3867,10 @@
     "@polkadex/types" "1.1.61"
     "@polkadex/utils" "1.1.46"
 
-"@polkadex/thea@^5.0.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@polkadex/thea/-/thea-5.1.0.tgz#ed10a57e953e40d202609f42bf804be666779e05"
-  integrity sha512-V8uRPtJ0RiB5xR1VRq7lv01Eyoh5uIia4Vi6RRWBCiLBhM9Ye9KF6KF8q5SSV5Uu4t9GJt8nX4u+LsrCuCj/8w==
+"@polkadex/thea@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@polkadex/thea/-/thea-5.2.0.tgz#d8ca68e5ef28efed207967206497b967e4e0596a"
+  integrity sha512-GUDOB7isG3UV1I3XmVqQZAot1O75vh6yxvpHmXZzQPKwMpzCWvRV1hF1hkdOXr+/VOu0KXSlv9duj1AhLo64Ng==
   dependencies:
     "@moonbeam-network/xcm-sdk" "^2.1.2"
     "@polkadex/numericals" "*"
@@ -3882,6 +3882,7 @@
     "@polkadot/util" "^12.6.2"
     "@polkadot/util-crypto" "^12.6.2"
     bignumber "^1.1.0"
+    lodash "^4.17.21"
     viem "^2.9.0"
 
 "@polkadex/types@1.1.61":
@@ -13679,6 +13680,7 @@ workbox-window@6.6.1, workbox-window@^6.5.4:
     workbox-core "6.6.1"
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3867,10 +3867,10 @@
     "@polkadex/types" "1.1.61"
     "@polkadex/utils" "1.1.46"
 
-"@polkadex/thea@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@polkadex/thea/-/thea-5.2.0.tgz#d8ca68e5ef28efed207967206497b967e4e0596a"
-  integrity sha512-GUDOB7isG3UV1I3XmVqQZAot1O75vh6yxvpHmXZzQPKwMpzCWvRV1hF1hkdOXr+/VOu0KXSlv9duj1AhLo64Ng==
+"@polkadex/thea@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@polkadex/thea/-/thea-5.3.0.tgz#69a49491a486dec72a4b357cad443563f6ba065f"
+  integrity sha512-oXf1k7J2HRdJRetYUygWhPKWaz1CvLdDgrSwJuVHPtvVDYnxsbQQdklHZWqpGoIcfQ5BDm3NA8Xwb3VsjOG+bQ==
   dependencies:
     "@moonbeam-network/xcm-sdk" "^2.1.2"
     "@polkadex/numericals" "*"
@@ -13726,6 +13726,7 @@ workbox-window@6.6.1, workbox-window@^6.5.4:
     workbox-core "6.6.1"
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Description

There are some feedbacks for new THEA UI - 

1. For a selected source chain and asset, destination chain is not being displayed properly. It always shows all the chains no matter what is source chain or asset. ✅

![Image](https://github.com/orgs/Polkadex-Substrate/projects/34/assets/65214523/837bc0a6-7bfe-494d-9e27-9de7d9ece7e3)

2. Balance on Asset PopUp & Input field is different. ✅

<img width="300" src="https://github.com/orgs/Polkadex-Substrate/projects/34/assets/65214523/0369523e-8f37-48b5-a0fb-8f7f7eea36d8" /> <img width="400" src="https://github.com/orgs/Polkadex-Substrate/projects/34/assets/65214523/fa174406-d74c-42f5-b21e-daed31e149be" />

3. `Balance` and `Available` looks misleading. Both shows different values as well. ✅

<img width="400" src="https://github.com/orgs/Polkadex-Substrate/projects/34/assets/65214523/ea57e352-e9a6-4640-82e7-3ec61f63058d" />

4. Sender Wallet & Source wallet both are same things. It should be Source and Destination wallet instead. ✅

<img width="400" src="https://github.com/orgs/Polkadex-Substrate/projects/34/assets/65214523/bd4f037c-be2f-4744-b3dc-78391da8218f" />

5.  Link for transfer history page

6. Upon selecting GLMR/EVM network deposits, the substrate account has to be deselected and a selection component for ETH wallet to be automatically triggered

7. Notification message to be updated: Deposit Success. Processed transactions take a few minutes to appear in History" ✅

8. Refactor THEA provider ✅

9. Amount formatting issue ✅

10. Fix Amount in Cross chain History table ✅


https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/9e2e7826-a925-47c1-a5af-a9fec841257c

## Checklist

<!--- Replace the space inside the square brackets with an 'x' to check off the items -->

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
