### PR TITLE
Added PDEX support b/w Moonbeam & Polkadex

### DIFF
--- a/apps/hestia/package.json
+++ b/apps/hestia/package.json
@@ -23,7 +23,7 @@
     "@polkadex/numericals": "^0.3.0",
     "@polkadex/polkadex-api": "^3.6.2",
     "@polkadex/subscan": "^1.1.61",
-    "@polkadex/thea": "^5.5.1",
+    "@polkadex/thea": "^5.6.0",
     "@polkadex/ux": "^6.26.0",
     "@polkadex/react-providers": "^2.2.1",
     "@polkadex/types": "^1.2.2",

--- a/apps/hestia/src/components/thea/Form/index.tsx
+++ b/apps/hestia/src/components/thea/Form/index.tsx
@@ -82,6 +82,20 @@ export const Form = () => {
     [poolsLoading, sourceBalancesLoading, transferConfigLoading]
   );
 
+  const minAmount = useMemo(() => {
+    const configMin = min?.amount || 0;
+    const destFee =
+      destinationFee?.ticker === selectedAsset?.ticker
+        ? destinationFee?.amount || 0
+        : 0;
+    return Math.max(configMin, destFee);
+  }, [
+    destinationFee?.amount,
+    destinationFee?.ticker,
+    min?.amount,
+    selectedAsset?.ticker,
+  ]);
+
   const {
     handleSubmit,
     errors,
@@ -94,7 +108,7 @@ export const Form = () => {
   } = useFormik({
     initialValues,
     validationSchema: bridgeValidations(
-      min?.amount,
+      minAmount,
       max?.amount,
       destinationPDEXBalance,
       selectedAssetBalance,

--- a/apps/hestia/src/components/thea/confirmTransaction.tsx
+++ b/apps/hestia/src/components/thea/confirmTransaction.tsx
@@ -56,6 +56,7 @@ export const ConfirmTransaction = ({
     isDestinationPolkadex,
     selectedAssetIdPolkadex,
   } = useTheaProvider();
+
   const { destinationFee, sourceFee, sourceFeeBalance, sourceFeeExistential } =
     transferConfig ?? {};
 

--- a/apps/hestia/src/components/thea/selectAsset.tsx
+++ b/apps/hestia/src/components/thea/selectAsset.tsx
@@ -12,7 +12,6 @@ import { SetStateAction, Dispatch, useCallback, ComponentProps } from "react";
 import classNames from "classnames";
 import { twMerge } from "tailwind-merge";
 import { useTheaProvider } from "@orderbook/core/providers";
-import { getChainFromTicker } from "@orderbook/core/helpers";
 
 import { formatAmount } from "@/helpers";
 
@@ -31,6 +30,7 @@ export const SelectAsset = ({
     onSelectAsset,
     sourceBalances,
     sourceBalancesLoading,
+    sourceChain,
   } = useTheaProvider();
 
   return (
@@ -63,7 +63,6 @@ export const SelectAsset = ({
                     className="[&_[cmdk-group-heading]]:px-3"
                   >
                     {supportedAssets?.map((e, i) => {
-                      const tokenName = getChainFromTicker(e.ticker);
                       const balance =
                         sourceBalances?.find((x) => x.ticker.includes(e.ticker))
                           ?.amount ?? 0;
@@ -83,7 +82,7 @@ export const SelectAsset = ({
                               key={e.id}
                               icon={e.ticker as TokenAppearance}
                               ticker={e.ticker}
-                              tokenName={tokenName}
+                              tokenName={sourceChain?.name || ""}
                               balance={formatAmount(balance)}
                               loading={sourceBalancesLoading}
                             />

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,7 @@
     "@polkadex/local-wallets": "^2.2.0",
     "@polkadex/polkadex-api": "^3.6.2",
     "@polkadex/react-providers": "^2.2.1",
-    "@polkadex/thea": "^5.5.1",
+    "@polkadex/thea": "^5.6.0",
     "@polkadex/utils": "^0.2.1",
     "@polkadot-cloud/assets": "^0.3.0",
     "@polkadot/api": "^10.12.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3866,10 +3866,10 @@
     "@polkadex/types" "1.1.61"
     "@polkadex/utils" "1.1.46"
 
-"@polkadex/thea@^5.5.1":
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadex/thea/-/thea-5.5.1.tgz#8a7313d999c3fa5db7614d52800a50af8a64c8b6"
-  integrity sha512-0aH1c/NYTp5dbhtViGGupf5TqPTLftrlB6wUgT2rUEiMd+UodThTAWgJyydzFIebpMMpL/30j4M1vrOa2DItmQ==
+"@polkadex/thea@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@polkadex/thea/-/thea-5.6.0.tgz#76b678a7059822c9c5d6ac0cb7b16b097ab64887"
+  integrity sha512-CX5a2ERlF+kt5QS3DVccOJrQN9MgfcHpQ6KCl9UioPuePKiAmHY0Z17MIdIJ0b/PdF8fNy2gfkI9d/5zQsjbow==
   dependencies:
     "@moonbeam-network/xcm-sdk" "^2.1.2"
     "@polkadex/numericals" "*"


### PR DESCRIPTION
## Description

This PR includes these changes - 

1. Upgraded THEA package so add PDEX asset could be transferred from Polkadex to Moonbeam and vice-versa.
2. Calculated `minAmount` value for a transfer considering destination fee

## Checklist

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
