### PR TITLE
Cross chain history fix

### DIFF
--- a/apps/hestia/src/components/thea/confirmTransaction.tsx
+++ b/apps/hestia/src/components/thea/confirmTransaction.tsx
@@ -56,7 +56,6 @@ export const ConfirmTransaction = ({
     isDestinationPolkadex,
     selectedAssetIdPolkadex,
   } = useTheaProvider();
-
   const { destinationFee, sourceFee, sourceFeeBalance, sourceFeeExistential } =
     transferConfig ?? {};
 

--- a/apps/hestia/src/components/transactions/TheaHistory/index.tsx
+++ b/apps/hestia/src/components/transactions/TheaHistory/index.tsx
@@ -38,7 +38,11 @@ const actionKeys = ["token", "date"];
 const responsiveKeys = ["hash", "date"];
 
 const polkadexConnector = getChainConnector(GENESIS[0]);
-const polkadexAssets = polkadexConnector?.getAllAssets() || [];
+const polkadexAssets =
+  polkadexConnector
+    ?.getAllAssets()
+    .map((e) => (!e.id ? { ...e, id: "0" } : e)) || [];
+
 const { getAllChains } = new Thea();
 const chains = getAllChains();
 

--- a/apps/hestia/src/components/transactions/TheaHistory/networkCard.tsx
+++ b/apps/hestia/src/components/transactions/TheaHistory/networkCard.tsx
@@ -22,7 +22,7 @@ export const NetworkCard = ({
           <Chain size="2xs" name={name} className="max-sm:hidden" />
           <div className="flex items-center gap-1">
             <Typography.Text size="sm">{name}</Typography.Text>
-            <RiInformationFill className="w-2.5 h-2.5 text-actionInput max-sm:hidden" />
+            <RiInformationFill className="w-3 h-3 text-actionInput" />
           </div>
         </div>
       </HoverCard.Trigger>

--- a/apps/hestia/src/components/transactions/TheaHistory/responsiveTable.tsx
+++ b/apps/hestia/src/components/transactions/TheaHistory/responsiveTable.tsx
@@ -40,7 +40,6 @@ export const ResponsiveTable = ({
 
   if (!data) return null;
 
-  console.log("asset?.ticker", asset?.ticker);
   return (
     <Drawer
       closeOnClickOutside


### PR DESCRIPTION
## Description

For PDEX asset transfer, history table is not showing it correctly. Instead of PDEX, it displays it as DOT wiht incorrect value as well.

<img width="1920" alt="image" src="https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/assets/65214523/20ed7869-ab85-464a-821b-fbbac5213206">


## Checklist

- [x] Included link to corresponding [Polkadex Orderbook Frontend Issue](https://github.com/Polkadex-Substrate/Polkadex-Orderbook-Frontend/issues).
- [x] I have tested these changes thoroughly.
- [x] I have requested a review from at least one other contributor.
